### PR TITLE
fix: remove adding of enhetsinformasjon value on alle-dataset

### DIFF
--- a/src/Dan.Plugin.Tilda/Metadata.cs
+++ b/src/Dan.Plugin.Tilda/Metadata.cs
@@ -21,7 +21,7 @@ using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Extensions.Options;
 using JsonSchema = NJsonSchema.JsonSchema;
 using Azure.Core.Serialization;
-using Dan.Plugin.Tilda.Models.AlertMessages;
+using AlertMessage = Dan.Plugin.Tilda.Models.AlertMessages.AlertMessage;
 
 namespace Dan.Plugin.Tilda
 {
@@ -261,7 +261,7 @@ namespace Dan.Plugin.Tilda
 
         private static List<EvidenceCode> GetTildaMeldingTilAnnenMyndighetMetadata()
         {
-            var schema = JsonSchema.FromType<AlertMessageList>().ToJson(Newtonsoft.Json.Formatting.Indented);
+            var schema = JsonSchema.FromType<AlertMessage>().ToJson(Formatting.Indented);
             var a = new EvidenceCode()
             {
                 Description = "TildaMeldingTilAnnenMyndighet v1",
@@ -277,7 +277,7 @@ namespace Dan.Plugin.Tilda
                 {
                     new EvidenceValue()
                     {
-                        EvidenceValueName = "meldingTilAnnenMyndighet",
+                        EvidenceValueName = "default",
                         Source = "Tilda",
                         ValueType = EvidenceValueType.JsonSchema,
                         JsonSchemaDefintion = schema

--- a/src/Dan.Plugin.Tilda/Tilda.cs
+++ b/src/Dan.Plugin.Tilda/Tilda.cs
@@ -711,9 +711,6 @@ namespace Dan.Plugin.Tilda
                 _logger.LogError(ex.Message);
             }
 
-            foreach (var unit in brResults)
-                ecb.AddEvidenceValue("enhetsinformasjon", JsonConvert.SerializeObject(unit), "Enhetsregisteret", false);
-
             if (result != null)
             {
                 var filtered = (TrendReportList)Helpers.Filter(result, brResults);
@@ -825,9 +822,6 @@ namespace Dan.Plugin.Tilda
             {
                 _logger.LogError(ex.Message);
             }
-
-            foreach (var unit in brResults)
-                ecb.AddEvidenceValue("enhetsinformasjon", JsonConvert.SerializeObject(unit), "Enhetsregisteret", false);
 
             if (result != null)
             {


### PR DESCRIPTION
### Description
Trendrapportalle and rapportalle attempted to return "enhetsinformasjon" evidence value. This should not've been done

Also a small change for the evidence metadata for alert message that was forgotten to be commited with the main pr

### Documentation
- [ ] Doc updated
