### PR TITLE
fix: add step for specifically removing not found orgs if geosrch on

### DIFF
--- a/src/Dan.Plugin.Tilda/Extensions/TildaParametersExtensions.cs
+++ b/src/Dan.Plugin.Tilda/Extensions/TildaParametersExtensions.cs
@@ -1,0 +1,18 @@
+﻿using Dan.Plugin.Tilda.Models;
+
+namespace Dan.Plugin.Tilda.Extensions;
+
+public static class TildaParametersExtensions
+{
+    public static bool HasGeoSearchParams(this TildaParameters parameters)
+    {
+        if (parameters is null)
+        {
+            return false;
+        }
+
+        return !string.IsNullOrEmpty(parameters.postcode) ||
+               !string.IsNullOrEmpty(parameters.municipalityNumber) ||
+               !string.IsNullOrEmpty(parameters.nace);
+    }
+}

--- a/src/Dan.Plugin.Tilda/Tilda.cs
+++ b/src/Dan.Plugin.Tilda/Tilda.cs
@@ -713,6 +713,12 @@ namespace Dan.Plugin.Tilda
 
             if (result != null)
             {
+                if (param.HasGeoSearchParams())
+                {
+                    var orgNumbers = brResults.Select(br => br.OrganizationNumber).ToList();
+                    result.TrendReports =
+                        result.TrendReports?.Where(r => orgNumbers.Contains(r.ControlObject)).ToList();
+                }
                 var filtered = (TrendReportList)Helpers.Filter(result, brResults);
                 ecb.AddEvidenceValue($"tilsynstrendrapporter", JsonConvert.SerializeObject(filtered, Formatting.None), result.ControlAgency, false);
             }
@@ -771,6 +777,12 @@ namespace Dan.Plugin.Tilda
 
             if (result != null)
             {
+                if (param.HasGeoSearchParams())
+                {
+                    var orgNumbers = brResults.Select(br => br.OrganizationNumber).ToList();
+                    result.AuditCoordinations =
+                        result.AuditCoordinations?.Where(r => orgNumbers.Contains(r.ControlObject)).ToList();
+                }
                 var filtered = (AuditCoordinationList)Helpers.Filter(result, brResults);
                 ecb.AddEvidenceValue($"tilsynskoordineringer", JsonConvert.SerializeObject(filtered, Formatting.None), result.ControlAgency, false);
             }
@@ -825,6 +837,12 @@ namespace Dan.Plugin.Tilda
 
             if (result != null)
             {
+                if (param.HasGeoSearchParams())
+                {
+                    var orgNumbers = brResults.Select(br => br.OrganizationNumber).ToList();
+                    result.AuditReports =
+                        result.AuditReports?.Where(r => orgNumbers.Contains(r.ControlObject)).ToList();
+                }
                 var filtered = (AuditReportList)Helpers.Filter(result, brResults);
                 ecb.AddEvidenceValue($"tilsynsrapporter", JsonConvert.SerializeObject(filtered, Formatting.None), result.ControlAgency, false);
             }


### PR DESCRIPTION
### Description
The existing filter method doesn't actually filter. It sanitises data based on if they are ENK. However if someone searches with geo search parameters, then we need to actually filter out the orgs that dont match. So adding a step to the "alle"-datasets to do that type of filtering if geo-search params are found

### Documentation
- [ ] Doc updated
