### PR TITLE
removed permissions and use long sha

### DIFF
--- a/.github/workflows/build-deploy-workflow.yml
+++ b/.github/workflows/build-deploy-workflow.yml
@@ -11,10 +11,7 @@ on:
 
 jobs:
  run:
-  permissions:
-    actions: read
-    contents: read
-  uses: data-altinn-no/deploy-actions/.github/workflows/dan-deploy-flow.yml@d08132e852a68b9e10b759cb30e23366219790b0
+  uses: data-altinn-no/deploy-actions/.github/workflows/dan-deploy-flow.yml@e9a1d62778d9d2f4e8c2245027fb2750fd230e0a
   with:
     artifact_name: 'dan-plugin-tilda' # Can be omitted, defaults to 'artifact'
     function_project_path: 'src/Dan.Plugin.Tilda'


### PR DESCRIPTION
### Description
<!--- What and why -->
removed permissions because they have been added to reused workflow and use long sha instead of short
### Documentation
- [x] Doc updated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the deployment workflow to use a newer version of the deploy action
  * Simplified job permissions configuration by removing explicit permission declarations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->