### PR TITLE
DAN-221: added permissions to workflow

### DIFF
--- a/.github/workflows/build-deploy-workflow.yml
+++ b/.github/workflows/build-deploy-workflow.yml
@@ -11,6 +11,9 @@ on:
 
 jobs:
  run:
+  permissions:
+    actions: read
+    contents: read
   uses: data-altinn-no/deploy-actions/.github/workflows/dan-deploy-flow.yml@e9a1d62778d9d2f4e8c2245027fb2750fd230e0a
   with:
     artifact_name: 'dan-plugin-tilda' # Can be omitted, defaults to 'artifact'


### PR DESCRIPTION
### Description
<!--- What and why -->
added permissions to workflow
### Documentation
- [x] Doc updated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow permissions to explicitly grant read access to actions and contents for improved security configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->