### PR TITLE
fix: reuse same azure cred instance

### DIFF
--- a/src/Dan.Plugin.Tilda/Program.cs
+++ b/src/Dan.Plugin.Tilda/Program.cs
@@ -76,8 +76,7 @@ var host = new HostBuilder()
         }
         else
         {
-            TokenCredential credential = new DefaultAzureCredential();
-            services.AddSingleton(_ => new CosmosClientBuilder(Settings.CosmosDbConnection, credential).Build());
+            services.AddSingleton(_ => new CosmosClientBuilder(Settings.CosmosDbConnection, credentials).Build());
 
         }
         services.AddSingleton<IEntityRegistryService, EntityRegistryService>();

--- a/src/Dan.Plugin.Tilda/Utils/Helpers.cs
+++ b/src/Dan.Plugin.Tilda/Utils/Helpers.cs
@@ -182,11 +182,20 @@ namespace Dan.Plugin.Tilda.Utils
 
             try
             {
-                result = await cache.GetValueAsync<List<BREntityRegisterEntry>>(cacheKey);
-                if (result is not null)
+                try
                 {
-                    return result;
+                    result = await cache.GetValueAsync<List<BREntityRegisterEntry>>(cacheKey);
+                    if (result is not null)
+                    {
+                        return result;
+                    }
                 }
+                catch (Exception)
+                {
+                    // Failing to get from cache, continue to get from source
+                    // When split into non-static class, do proper warning logging or something for these catches
+                }
+
                 result = [];
                 var response = await client.GetAsync(url);
                 if (response.StatusCode == HttpStatusCode.NotFound)
@@ -262,10 +271,17 @@ namespace Dan.Plugin.Tilda.Utils
                 var accountsUrl = $"http://data.brreg.no/regnskapsregisteret/regnskap/{organizationNumber}";
                 var cacheKey = $"Tilda-Cache_Absolute_GET_{accountsUrl}";
 
-                result = await cache.GetValueAsync<AccountsInformation>(cacheKey);
-                if (result is not null)
+                try
                 {
-                    return result;
+                    result = await cache.GetValueAsync<AccountsInformation>(cacheKey);
+                    if (result is not null)
+                    {
+                        return result;
+                    }
+                }
+                catch (Exception)
+                {
+                    // Failing to get from cache, continue to get from source
                 }
 
                 result = new AccountsInformation();
@@ -312,10 +328,17 @@ namespace Dan.Plugin.Tilda.Utils
             string rawResult;
             try
             {
-                result = await cache.GetValueAsync<BREntityRegisterEntry>(cacheKey);
-                if (result is not null)
+                try
                 {
-                    return result;
+                    result = await cache.GetValueAsync<BREntityRegisterEntry>(cacheKey);
+                    if (result is not null)
+                    {
+                        return result;
+                    }
+                }
+                catch (Exception)
+                {
+                    // Failing to get from cache, continue to get from source
                 }
 
                 var response = await client.GetAsync(mainUnitUrl);


### PR DESCRIPTION
### Description
Reusing same DefaultAzureCredential instance, using multiple can cause auth issues
Also catch and continue on redis fetch errors, if we fail to get from redis, just get from source

Ideally want to add better logging here, but passing through logger to each helper method is tedious, it would be better and cause less trouble in the future to rewrite that class so it can be injected where needed (and split up based on context rather than just a universal helper class), so I opted not to do that now

### Documentation
- [ ] Doc updated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for data retrieval operations, ensuring the system gracefully falls back to primary data sources when cache access encounters issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->