### PR TITLE
feat: only fetch br org info if geo search is included for filtering

### DIFF
--- a/src/Dan.Plugin.Tilda/Functions/AuditCoordinationFunctions.cs
+++ b/src/Dan.Plugin.Tilda/Functions/AuditCoordinationFunctions.cs
@@ -124,7 +124,7 @@ public class AuditCoordinationFunctions(
         }
         catch (Exception ex)
         {
-            logger.LogError("{message}", ex.Message);
+            logger.LogError("Failed getting TilsynsKoordineringAlle for org {OrganizationNumber}: {message}", req.OrganizationNumber, ex.Message);
         }
 
         if (result == null)
@@ -135,39 +135,46 @@ public class AuditCoordinationFunctions(
         var brResults = new List<TildaRegistryEntry>();
         if (param.HasGeoSearchParams())
         {
-            var taskList = new List<Task<TildaRegistryEntry>>();
-
-            if (result.AuditCoordinations != null)
-            {
-                var distinctList = result.AuditCoordinations.GroupBy(x => x.ControlObject).Select(y => y.FirstOrDefault()).ToList();
-                taskList.AddRange(distinctList.Select(item => GetOrganizationFromBr(item.ControlObject, param)));
-            }
-
-            var taskResult = Task.WhenAll(taskList);
             try
             {
-                await taskResult;
-            }
-            catch (Exception)
-            {
-                // Don't want one failed fetch to break the listing of the rest of the orgs
-                if (taskResult.IsFaulted)
-                {
-                    var failedTasks = taskList.Where(task => task.IsFaulted).ToList();
-                    foreach (var task in failedTasks)
-                    {
-                        logger.LogError(task.Exception, "{message}", task.Exception?.Message);
-                    }
-                    taskList = taskList.Where(task => !task.IsFaulted).ToList();
-                }
-            }
-            taskList = taskList
-                .Where(task => task.Result is not null)
-                .GroupBy(x => x.Result.OrganizationNumber)
-                .Select(y => y.FirstOrDefault())
-                .ToList();
+                var taskList = new List<Task<TildaRegistryEntry>>();
 
-            brResults.AddRange(taskList.Select(t => t.Result));
+                if (result.AuditCoordinations != null)
+                {
+                    var distinctList = result.AuditCoordinations.GroupBy(x => x.ControlObject).Select(y => y.FirstOrDefault()).ToList();
+                    taskList.AddRange(distinctList.Select(item => GetOrganizationFromBr(item.ControlObject, param)));
+                }
+
+                var taskResult = Task.WhenAll(taskList);
+                try
+                {
+                    await taskResult;
+                }
+                catch (Exception)
+                {
+                    // Don't want one failed fetch to break the listing of the rest of the orgs
+                    if (taskResult.IsFaulted)
+                    {
+                        var failedTasks = taskList.Where(task => task.IsFaulted).ToList();
+                        foreach (var task in failedTasks)
+                        {
+                            logger.LogError(task.Exception, "{message}", task.Exception?.Message);
+                        }
+                        taskList = taskList.Where(task => !task.IsFaulted).ToList();
+                    }
+                }
+                taskList = taskList
+                    .Where(task => task.Result is not null)
+                    .GroupBy(x => x.Result.OrganizationNumber)
+                    .Select(y => y.FirstOrDefault())
+                    .ToList();
+
+                brResults.AddRange(taskList.Select(t => t.Result));
+            }
+            catch (Exception ex)
+            {
+                logger.LogError("Failed getting TilsynsKoordineringAlle org info for org {OrganizationNumber}: {message}", req.OrganizationNumber, ex.Message);
+            }
 
             var orgNumbers = brResults.Select(br => br.OrganizationNumber).ToList();
             result.AuditCoordinations =

--- a/src/Dan.Plugin.Tilda/Functions/AuditCoordinationFunctions.cs
+++ b/src/Dan.Plugin.Tilda/Functions/AuditCoordinationFunctions.cs
@@ -102,9 +102,7 @@ public class AuditCoordinationFunctions(
     {
         var sourceList = tildaSourceProvider.GetRelevantSources<ITildaAuditCoordinationAll>(req.OrganizationNumber).ToList();
         AuditCoordinationList result = null;
-        var brResults = new List<TildaRegistryEntry>();
         var ecb = new EvidenceBuilder(metadata, "TildaTilsynskoordineringAllev1");
-
 
         //should only return the one source
         if (sourceList.Count != 1)
@@ -123,7 +121,20 @@ public class AuditCoordinationFunctions(
             {
                 result.AuditCoordinations = null;
             }
+        }
+        catch (Exception ex)
+        {
+            logger.LogError("{message}", ex.Message);
+        }
 
+        if (result == null)
+        {
+            return ecb.GetEvidenceValues();
+        }
+
+        var brResults = new List<TildaRegistryEntry>();
+        if (param.HasGeoSearchParams())
+        {
             var taskList = new List<Task<TildaRegistryEntry>>();
 
             if (result.AuditCoordinations != null)
@@ -157,23 +168,12 @@ public class AuditCoordinationFunctions(
                 .ToList();
 
             brResults.AddRange(taskList.Select(t => t.Result));
-        }
-        catch (Exception ex)
-        {
-            logger.LogError("{message}", ex.Message);
-        }
 
-        if (result == null)
-        {
-            return ecb.GetEvidenceValues();
-        }
-
-        if (param.HasGeoSearchParams())
-        {
             var orgNumbers = brResults.Select(br => br.OrganizationNumber).ToList();
             result.AuditCoordinations =
                 result.AuditCoordinations?.Where(r => orgNumbers.Contains(r.ControlObject)).ToList();
         }
+        // If brResults is null or empty, filtered will be the same as it was before
         var filtered = (AuditCoordinationList)filterService.FilterAuditList(result, brResults);
         ecb.AddEvidenceValue($"tilsynskoordineringer", JsonConvert.SerializeObject(filtered, Formatting.None), result.ControlAgency, false);
 

--- a/src/Dan.Plugin.Tilda/Functions/AuditReportFunctions.cs
+++ b/src/Dan.Plugin.Tilda/Functions/AuditReportFunctions.cs
@@ -120,7 +120,6 @@ public class AuditReportFunctions(
             throw new EvidenceSourcePermanentServerException(1001, $"Angitt kilde ({req.OrganizationNumber}) støtter ikke datasettet");
         }
 
-
         try
         {
             result = await tildaAuditReportsAlls.First().GetAuditReportsAllAsync(req, param.month, param.year, param.filter);
@@ -135,7 +134,7 @@ public class AuditReportFunctions(
         }
         catch (Exception ex)
         {
-            logger.LogError(ex.Message);
+            logger.LogError("Failed getting TilsynsRapportAlle for org {OrganizationNumber}: {message}", req.OrganizationNumber, ex.Message);
         }
 
         if (result == null)
@@ -146,39 +145,46 @@ public class AuditReportFunctions(
         var brResults = new List<TildaRegistryEntry>();
         if (param.HasGeoSearchParams())
         {
-            var taskList = new List<Task<TildaRegistryEntry>>();
-
-            if (result.AuditReports != null)
-            {
-                var distinctList = result.AuditReports.GroupBy(x => x.ControlObject).Select(y => y.FirstOrDefault())
-                    .ToList();
-                taskList.AddRange(distinctList.Select(item => GetOrganizationFromBr(item.ControlObject, param)));
-            }
-
-            var taskResult = Task.WhenAll(taskList);
             try
             {
-                await taskResult;
-            }
-            catch (Exception)
-            {
-                // Don't want one failed fetch to break the listing of the rest of the orgs
-                if (taskResult.IsFaulted)
+                var taskList = new List<Task<TildaRegistryEntry>>();
+
+                if (result.AuditReports != null)
                 {
-                    var failedTasks = taskList.Where(task => task.IsFaulted).ToList();
-                    foreach (var task in failedTasks)
-                    {
-                        logger.LogError(task.Exception, task.Exception?.Message);
-                    }
-
-                    taskList = taskList.Where(task => !task.IsFaulted).ToList();
+                    var distinctList = result.AuditReports.GroupBy(x => x.ControlObject).Select(y => y.FirstOrDefault())
+                        .ToList();
+                    taskList.AddRange(distinctList.Select(item => GetOrganizationFromBr(item.ControlObject, param)));
                 }
-            }
 
-            taskList = taskList
-                .Where(task => task.Result is not null)
-                .ToList();
-            brResults.AddRange(taskList.Select(t => t.Result));
+                var taskResult = Task.WhenAll(taskList);
+                try
+                {
+                    await taskResult;
+                }
+                catch (Exception)
+                {
+                    // Don't want one failed fetch to break the listing of the rest of the orgs
+                    if (taskResult.IsFaulted)
+                    {
+                        var failedTasks = taskList.Where(task => task.IsFaulted).ToList();
+                        foreach (var task in failedTasks)
+                        {
+                            logger.LogError(task.Exception, task.Exception?.Message);
+                        }
+
+                        taskList = taskList.Where(task => !task.IsFaulted).ToList();
+                    }
+                }
+
+                taskList = taskList
+                    .Where(task => task.Result is not null)
+                    .ToList();
+                brResults.AddRange(taskList.Select(t => t.Result));
+            }
+            catch (Exception ex)
+            {
+                logger.LogError("Failed getting TilsynsRapportAlle org data for org {OrganizationNumber}: {message}", req.OrganizationNumber, ex.Message);
+            }
 
             var orgNumbers = brResults.Select(br => br.OrganizationNumber).ToList();
             result.AuditReports =

--- a/src/Dan.Plugin.Tilda/Functions/AuditReportFunctions.cs
+++ b/src/Dan.Plugin.Tilda/Functions/AuditReportFunctions.cs
@@ -110,7 +110,6 @@ public class AuditReportFunctions(
     {
         var sourceList = tildaSourceProvider.GetRelevantSources<ITildaAuditReportsAll>(req.OrganizationNumber);
         AuditReportList result = null;
-        var brResults = new List<TildaRegistryEntry>();
         var ecb = new EvidenceBuilder(metadata, "TildaTilsynsrapportAllev1");
 
 
@@ -133,7 +132,20 @@ public class AuditReportFunctions(
             {
                 result.AuditReports = null;
             }
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex.Message);
+        }
 
+        if (result == null)
+        {
+            return ecb.GetEvidenceValues();
+        }
+
+        var brResults = new List<TildaRegistryEntry>();
+        if (param.HasGeoSearchParams())
+        {
             var taskList = new List<Task<TildaRegistryEntry>>();
 
             if (result.AuditReports != null)
@@ -167,24 +179,13 @@ public class AuditReportFunctions(
                 .Where(task => task.Result is not null)
                 .ToList();
             brResults.AddRange(taskList.Select(t => t.Result));
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex.Message);
-        }
 
-        if (result == null)
-        {
-            return ecb.GetEvidenceValues();
-        }
-
-        if (param.HasGeoSearchParams())
-        {
             var orgNumbers = brResults.Select(br => br.OrganizationNumber).ToList();
             result.AuditReports =
                 result.AuditReports?.Where(r => orgNumbers.Contains(r.ControlObject)).ToList();
         }
 
+        // If brResults is null or empty, filtered will be the same as it was before
         var filtered = (AuditReportList)filterService.FilterAuditList(result, brResults);
         ecb.AddEvidenceValue("tilsynsrapporter", JsonConvert.SerializeObject(filtered, Formatting.None),
             result.ControlAgency, false);

--- a/src/Dan.Plugin.Tilda/Functions/TrendReportFunctions.cs
+++ b/src/Dan.Plugin.Tilda/Functions/TrendReportFunctions.cs
@@ -129,7 +129,7 @@ public class TrendReportFunctions(
         }
         catch (Exception ex)
         {
-            logger.LogError(ex.Message);
+            logger.LogError("Failed getting TrendRapportAlle for org {OrganizationNumber}: {message}", req.OrganizationNumber, ex.Message);
         }
 
         if (result == null)
@@ -140,34 +140,41 @@ public class TrendReportFunctions(
         var brResults = new List<TildaRegistryEntry>();
         if (param.HasGeoSearchParams())
         {
-            var taskList = new List<Task<TildaRegistryEntry>>();
-
-            if (result.TrendReports != null)
-            {
-                var distinctList = result.TrendReports.GroupBy(x => x.ControlObject).Select(y => y.FirstOrDefault()).ToList();
-                taskList.AddRange(distinctList.Select(item => GetOrganizationFromBr(item.ControlObject, param)));
-            }
-
-            var taskResult = Task.WhenAll(taskList);
             try
             {
-                await taskResult;
-            }
-            catch (Exception)
-            {
-                // Don't want one failed fetch to break the listing of the rest of the orgs
-                if (taskResult.IsFaulted)
-                {
-                    var failedTasks = taskList.Where(task => task.IsFaulted).ToList();
-                    foreach (var task in failedTasks)
-                    {
-                        logger.LogError(task.Exception, "{message}", task.Exception?.Message);
-                    }
-                    taskList = taskList.Where(task => !task.IsFaulted).ToList();
-                }
-            }
+                var taskList = new List<Task<TildaRegistryEntry>>();
 
-            brResults.AddRange(taskList.Select(t => t.Result));
+                if (result.TrendReports != null)
+                {
+                    var distinctList = result.TrendReports.GroupBy(x => x.ControlObject).Select(y => y.FirstOrDefault()).ToList();
+                    taskList.AddRange(distinctList.Select(item => GetOrganizationFromBr(item.ControlObject, param)));
+                }
+
+                var taskResult = Task.WhenAll(taskList);
+                try
+                {
+                    await taskResult;
+                }
+                catch (Exception)
+                {
+                    // Don't want one failed fetch to break the listing of the rest of the orgs
+                    if (taskResult.IsFaulted)
+                    {
+                        var failedTasks = taskList.Where(task => task.IsFaulted).ToList();
+                        foreach (var task in failedTasks)
+                        {
+                            logger.LogError(task.Exception, "{message}", task.Exception?.Message);
+                        }
+                        taskList = taskList.Where(task => !task.IsFaulted).ToList();
+                    }
+                }
+
+                brResults.AddRange(taskList.Select(t => t.Result));
+            }
+            catch (Exception ex)
+            {
+                logger.LogError("Failed getting TrendRapportAlle org info for org {OrganizationNumber}: {message}", req.OrganizationNumber, ex.Message);
+            }
 
             var orgNumbers = brResults.Select(br => br.OrganizationNumber).ToList();
             result.TrendReports =

--- a/src/Dan.Plugin.Tilda/Functions/TrendReportFunctions.cs
+++ b/src/Dan.Plugin.Tilda/Functions/TrendReportFunctions.cs
@@ -107,9 +107,7 @@ public class TrendReportFunctions(
     {
         var sourceList = tildaSourceProvider.GetRelevantSources<ITildaTrendReportsAll>(req.OrganizationNumber).ToList();
         TrendReportList result = null;
-        var brResults = new List<TildaRegistryEntry>();
         var ecb = new EvidenceBuilder(metadata, "TildaTrendrapportAllev1");
-
 
         //should only return the one source
         if (sourceList.Count!= 1)
@@ -128,7 +126,20 @@ public class TrendReportFunctions(
             {
                 result.TrendReports = null;
             }
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex.Message);
+        }
 
+        if (result == null)
+        {
+            return ecb.GetEvidenceValues();
+        }
+
+        var brResults = new List<TildaRegistryEntry>();
+        if (param.HasGeoSearchParams())
+        {
             var taskList = new List<Task<TildaRegistryEntry>>();
 
             if (result.TrendReports != null)
@@ -157,25 +168,14 @@ public class TrendReportFunctions(
             }
 
             brResults.AddRange(taskList.Select(t => t.Result));
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex.Message);
-        }
 
-        if (result == null)
-        {
-            return ecb.GetEvidenceValues();
-        }
-
-        if (param.HasGeoSearchParams())
-        {
             var orgNumbers = brResults.Select(br => br.OrganizationNumber).ToList();
             result.TrendReports =
                 result.TrendReports?.Where(r => orgNumbers.Contains(r.ControlObject)).ToList();
         }
+        // If brResults is null or empty, filtered will be the same as it was before
         var filtered = (TrendReportList)filterService.FilterAuditList(result, brResults);
-        ecb.AddEvidenceValue($"tilsynstrendrapporter", JsonConvert.SerializeObject(filtered, Formatting.None), result.ControlAgency, false);
+        ecb.AddEvidenceValue("tilsynstrendrapporter", JsonConvert.SerializeObject(filtered, Formatting.None), result.ControlAgency, false);
 
         return ecb.GetEvidenceValues();
     }

--- a/src/Dan.Plugin.Tilda/Functions/TrendReportFunctions.cs
+++ b/src/Dan.Plugin.Tilda/Functions/TrendReportFunctions.cs
@@ -168,6 +168,11 @@ public class TrendReportFunctions(
                         taskList = taskList.Where(task => !task.IsFaulted).ToList();
                     }
                 }
+                taskList = taskList
+                    .Where(task => task.Result is not null)
+                    .GroupBy(x => x.Result.OrganizationNumber)
+                    .Select(y => y.FirstOrDefault())
+                    .ToList();
 
                 brResults.AddRange(taskList.Select(t => t.Result));
             }


### PR DESCRIPTION
### Description
In order to reduce load, will only fetch organisation information from brreg during "alle"-datasets if the search parameters include geo-search params.

Note: skipping npdid for this because it's relatively little used and will be refactored next.

### Documentation
- [ ] Doc updated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal reorganization of control flow, initialization timing, and error handling across audit coordination, reporting, and trend processing.
  * Adjusted geo-search filtering logic to ensure consistent behavior when registry lookups are empty or unavailable.
  * No changes to public interfaces or user-facing features; behavior and functionality remain unchanged.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/data-altinn-no/plugin-tilda/pull/77?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->