### PR TITLE
Performance and concurrency improvements

### DIFF
--- a/src/Dan.Plugin.Tilda/Config/Settings.cs
+++ b/src/Dan.Plugin.Tilda/Config/Settings.cs
@@ -42,14 +42,14 @@ namespace Dan.Plugin.Tilda.Config
         private static X509Certificate2 _kofuviCertificate { get; set; }
         public static X509Certificate2 KofuviCertificate
         {
-            get => _kofuviCertificate ?? new KeyVault(KeyVaultName).GetCertificate(KofuviCertificateName).Result;
+            get => _kofuviCertificate ??= new KeyVault(KeyVaultName).GetCertificate(KofuviCertificateName).Result;
             set => _kofuviCertificate = value;
         }
 
         private X509Certificate2 _digdirCertificate { get; set; }
         public X509Certificate2 DigdirCertificate
         {
-            get => _digdirCertificate ?? new KeyVault(KeyVaultName).GetCertificate(DigdirCertificateName).Result;
+            get => _digdirCertificate ??= new KeyVault(KeyVaultName).GetCertificate(DigdirCertificateName).Result;
             set => _digdirCertificate = value;
         }
 

--- a/src/Dan.Plugin.Tilda/Config/Settings.cs
+++ b/src/Dan.Plugin.Tilda/Config/Settings.cs
@@ -22,9 +22,6 @@ namespace Dan.Plugin.Tilda.Config
 
         public bool IsLocalDevelopment { get; set; }
 
-        public string Breaker_RetryWaitTime { get; set; }
-        public string Breaker_OpenCircuitTime { get; set; }
-
         public string KofuviEndpoint { get; set; }
         public string KvName { get; set; }
         public string KvKofuviCertificateName { get; set; }

--- a/src/Dan.Plugin.Tilda/Dan.Plugin.Tilda.csproj
+++ b/src/Dan.Plugin.Tilda/Dan.Plugin.Tilda.csproj
@@ -22,6 +22,7 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.7" OutputItemType="Analyzer" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.3.0" />
     <PackageReference Include="Microsoft.Azure.StackExchangeRedis" Version="3.3.1" />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.6.0" />
     <PackageReference Include="Polly.Extensions" Version="8.6.6" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Dan.Plugin.Tilda/Dan.Plugin.Tilda.csproj
+++ b/src/Dan.Plugin.Tilda/Dan.Plugin.Tilda.csproj
@@ -3,6 +3,9 @@
     <TargetFramework>net10.0</TargetFramework>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <OutputType>Exe</OutputType>
+    <!-- Isolated workers are console apps and default to workstation GC; this workload is
+         allocation-heavy (large JSON payloads fanned out across ~26 sources per request) -->
+    <ServerGarbageCollection>true</ServerGarbageCollection>
   </PropertyGroup>
   <ItemGroup>
     <None Remove="worker-logging.json" />

--- a/src/Dan.Plugin.Tilda/Extensions/HttpClientExtensions.cs
+++ b/src/Dan.Plugin.Tilda/Extensions/HttpClientExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Dan.Tilda.Models.Audits;
@@ -31,15 +32,22 @@ public static class HttpClientExtensions
             logger.LogInformation(
                 "Data retrieval started from sourceOrgNo={sourceOrgNo} on url={url} from requestor={requestor}",
                 sourceOrgNo, url, requestor);
-            var result = await client.SendAsync(request);
+            // Note: buffered send (default completion option) so HttpClient.Timeout covers the
+            // body download; with ResponseHeadersRead a stalled body would hang indefinitely
+            using var result = await client.SendAsync(request);
             logger.LogInformation(
                 "Data retrieval completed from sourceOrgNo={sourceOrgNo} on url={url} from requestor={requestor} elapsedMs={elapsedMs} status={status}",
                 sourceOrgNo, url, requestor, t.ElapsedMilliseconds, "ok");
 
             if (result.IsSuccessStatusCode)
             {
-                var body = await result.Content.ReadAsStringAsync();
-                resultList = JsonConvert.DeserializeObject<T>(body);
+                // Deserialize from the buffered response stream instead of materializing the body
+                // as a string first; "Alle" payloads are large enough that the intermediate string
+                // (~2x payload size) would land on the large object heap
+                await using var stream = await result.Content.ReadAsStreamAsync();
+                using var streamReader = new StreamReader(stream);
+                using var jsonReader = new JsonTextReader(streamReader);
+                resultList = JsonSerializer.CreateDefault().Deserialize<T>(jsonReader);
                 if (resultList == null)
                 {
                     resultList = new T();
@@ -111,7 +119,7 @@ public static class HttpClientExtensions
 
             logger.LogInformation("Data retrieval started from sourceOrgNo={sourceOrgNo} on url={url} from requestor={requestor}",
                 sourceOrgNo, url, requestor);
-            var responseMessage = await client.SendAsync(request);
+            using var responseMessage = await client.SendAsync(request);
             logger.LogInformation(
                 "Data retrieval completed from sourceOrgNo={sourceOrgNo} on url={url} from requestor={requestor} elapsedMs={elapsedMs} status={status}",
                 sourceOrgNo, url, requestor, t.ElapsedMilliseconds, "ok");

--- a/src/Dan.Plugin.Tilda/Extensions/HttpClientExtensions.cs
+++ b/src/Dan.Plugin.Tilda/Extensions/HttpClientExtensions.cs
@@ -68,6 +68,10 @@ public static class HttpClientExtensions
         }
         catch (TaskCanceledException ex) when (ex.InnerException is TimeoutException)
         {
+            resultList.SetStatusAndTextAndOwner(
+                $"Failed: timeout when retrieving data from {sourceOrgNo}. ElapsedMs: {t.ElapsedMilliseconds}",
+                StatusEnum.Failed, sourceOrgNo);
+
             logger.LogError("Timeout when fetching data sourceOrgNo={sourceOrgNo} on url={url} from requestor={requestor} elapsedMs={elapsedMs} ex={ex} message={message} status={status}",
                 sourceOrgNo, url, requestor, t.ElapsedMilliseconds, ex.GetType().Name, ex.Message, "hardfail");
         }

--- a/src/Dan.Plugin.Tilda/Functions/AuditCoordinationFunctions.cs
+++ b/src/Dan.Plugin.Tilda/Functions/AuditCoordinationFunctions.cs
@@ -137,39 +137,11 @@ public class AuditCoordinationFunctions(
         {
             try
             {
-                var taskList = new List<Task<TildaRegistryEntry>>();
-
                 if (result.AuditCoordinations != null)
                 {
-                    var distinctList = result.AuditCoordinations.GroupBy(x => x.ControlObject).Select(y => y.FirstOrDefault()).ToList();
-                    taskList.AddRange(distinctList.Select(item => GetOrganizationFromBr(item.ControlObject, param)));
+                    var distinctOrgs = result.AuditCoordinations.Select(x => x.ControlObject).Distinct().ToList();
+                    brResults.AddRange(await GetOrganizationsFromBrBounded(distinctOrgs, param, logger));
                 }
-
-                var taskResult = Task.WhenAll(taskList);
-                try
-                {
-                    await taskResult;
-                }
-                catch (Exception)
-                {
-                    // Don't want one failed fetch to break the listing of the rest of the orgs
-                    if (taskResult.IsFaulted)
-                    {
-                        var failedTasks = taskList.Where(task => task.IsFaulted).ToList();
-                        foreach (var task in failedTasks)
-                        {
-                            logger.LogError(task.Exception, "{message}", task.Exception?.Message);
-                        }
-                        taskList = taskList.Where(task => !task.IsFaulted).ToList();
-                    }
-                }
-                taskList = taskList
-                    .Where(task => task.Result is not null)
-                    .GroupBy(x => x.Result.OrganizationNumber)
-                    .Select(y => y.FirstOrDefault())
-                    .ToList();
-
-                brResults.AddRange(taskList.Select(t => t.Result));
             }
             catch (Exception ex)
             {

--- a/src/Dan.Plugin.Tilda/Functions/AuditCoordinationFunctions.cs
+++ b/src/Dan.Plugin.Tilda/Functions/AuditCoordinationFunctions.cs
@@ -148,7 +148,7 @@ public class AuditCoordinationFunctions(
                 logger.LogError("Failed getting TilsynsKoordineringAlle org info for org {OrganizationNumber}: {message}", req.OrganizationNumber, ex.Message);
             }
 
-            var orgNumbers = brResults.Select(br => br.OrganizationNumber).ToList();
+            var orgNumbers = brResults.Select(br => br.OrganizationNumber).ToHashSet();
             result.AuditCoordinations =
                 result.AuditCoordinations?.Where(r => orgNumbers.Contains(r.ControlObject)).ToList();
         }

--- a/src/Dan.Plugin.Tilda/Functions/AuditFunctionsBase.cs
+++ b/src/Dan.Plugin.Tilda/Functions/AuditFunctionsBase.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -9,11 +10,18 @@ using Dan.Plugin.Tilda.Models;
 using Dan.Plugin.Tilda.Services;
 using Dan.Tilda.Models.Entities;
 using Dan.Tilda.Models.Enums;
+using Microsoft.Extensions.Logging;
 
 namespace Dan.Plugin.Tilda.Functions;
 
 public abstract class AuditFunctionsBase(IBrregService brregService)
 {
+    // Caps the outbound fan-out when enriching "Alle" results with org info from BR.
+    // Each lookup can spawn up to 3 sequential HTTP calls (enheter, regnskap, kofuvi),
+    // so unbounded parallelism over hundreds of orgs risks SNAT port exhaustion and
+    // rate limiting from BR on cold cache.
+    private const int MaxConcurrentBrLookups = 16;
+
     protected static TildaParameters GetValuesFromParameters(EvidenceHarvesterRequest req)
     {
         DateTime? fromDateTime = null;
@@ -74,6 +82,41 @@ public abstract class AuditFunctionsBase(IBrregService brregService)
         }
 
         return organization;
+    }
+
+    /// <summary>
+    /// Looks up org info from BR for a set of organization numbers with bounded parallelism.
+    /// Failed lookups are logged and skipped so one failed fetch doesn't break the listing
+    /// of the rest of the orgs. Results filtered out by <paramref name="param"/> are excluded.
+    /// </summary>
+    protected async Task<List<TildaRegistryEntry>> GetOrganizationsFromBrBounded(
+        IEnumerable<string> organizationNumbers, TildaParameters param, ILogger logger)
+    {
+        var results = new ConcurrentBag<TildaRegistryEntry>();
+        await Parallel.ForEachAsync(
+            organizationNumbers.Distinct(),
+            new ParallelOptions { MaxDegreeOfParallelism = MaxConcurrentBrLookups },
+            async (organizationNumber, _) =>
+            {
+                try
+                {
+                    var entry = await GetOrganizationFromBr(organizationNumber, param);
+                    if (entry is not null)
+                    {
+                        results.Add(entry);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    logger.LogError(ex, "Failed getting org info from BR for org {OrganizationNumber}: {message}",
+                        organizationNumber, ex.Message);
+                }
+            });
+
+        return results
+            .GroupBy(x => x.OrganizationNumber)
+            .Select(y => y.First())
+            .ToList();
     }
 
     protected async Task<List<TildaRegistryEntry>> GetOrganizationsFromBr(string organizationNumber)

--- a/src/Dan.Plugin.Tilda/Functions/AuditFunctionsBase.cs
+++ b/src/Dan.Plugin.Tilda/Functions/AuditFunctionsBase.cs
@@ -60,7 +60,6 @@ public abstract class AuditFunctionsBase(IBrregService brregService)
     {
         var brResult = await brregService.GetFromBr(organizationNumber, false);
         var brEntity = brResult.First();
-        AccountsInformation accountsInformation = null;
 
         // Filters out on parameters, currently only on "geo search" params
         if (!brEntity.MatchesFilterParameters(tildaParameters))
@@ -68,12 +67,14 @@ public abstract class AuditFunctionsBase(IBrregService brregService)
             return null;
         }
 
-        if (brEntity.Organisasjonsform?.Kode != "ENK")
-        {
-            accountsInformation = await brregService.GetAnnualTurnoverFromBr(organizationNumber);
-        }
-
-        var kofuviAddresses = await brregService.GetKofuviAddresses(organizationNumber);
+        // Annual turnover and kofuvi addresses are independent lookups, fetch them in parallel
+        var accountsTask = brEntity.Organisasjonsform?.Kode != "ENK"
+            ? brregService.GetAnnualTurnoverFromBr(organizationNumber)
+            : Task.FromResult<AccountsInformation>(null);
+        var kofuviTask = brregService.GetKofuviAddresses(organizationNumber);
+        await Task.WhenAll(accountsTask, kofuviTask);
+        var accountsInformation = accountsTask.Result;
+        var kofuviAddresses = kofuviTask.Result;
 
         var organization = ConvertBRtoTilda(brEntity, accountsInformation);
         if (kofuviAddresses.Count > 0)
@@ -124,13 +125,15 @@ public abstract class AuditFunctionsBase(IBrregService brregService)
         var result = new List<TildaRegistryEntry>();
         var brResult = await brregService.GetFromBr(organizationNumber, false);
         var brEntity = brResult.First();
-        AccountsInformation accountsInformation = null;
-        if (string.IsNullOrEmpty(brEntity.OverordnetEnhet) && brEntity.Organisasjonsform?.Kode != "ENK")
-        {
-            accountsInformation = await brregService.GetAnnualTurnoverFromBr(organizationNumber);
-        }
 
-        var kofuviAddresses = await brregService.GetKofuviAddresses(organizationNumber);
+        // Annual turnover and kofuvi addresses are independent lookups, fetch them in parallel
+        var accountsTask = string.IsNullOrEmpty(brEntity.OverordnetEnhet) && brEntity.Organisasjonsform?.Kode != "ENK"
+            ? brregService.GetAnnualTurnoverFromBr(organizationNumber)
+            : Task.FromResult<AccountsInformation>(null);
+        var kofuviTask = brregService.GetKofuviAddresses(organizationNumber);
+        await Task.WhenAll(accountsTask, kofuviTask);
+        var accountsInformation = accountsTask.Result;
+        var kofuviAddresses = kofuviTask.Result;
 
         var organization = ConvertBRtoTilda(brEntity, accountsInformation);
         if (kofuviAddresses.Count > 0)

--- a/src/Dan.Plugin.Tilda/Functions/AuditReportFunctions.cs
+++ b/src/Dan.Plugin.Tilda/Functions/AuditReportFunctions.cs
@@ -147,39 +147,11 @@ public class AuditReportFunctions(
         {
             try
             {
-                var taskList = new List<Task<TildaRegistryEntry>>();
-
                 if (result.AuditReports != null)
                 {
-                    var distinctList = result.AuditReports.GroupBy(x => x.ControlObject).Select(y => y.FirstOrDefault())
-                        .ToList();
-                    taskList.AddRange(distinctList.Select(item => GetOrganizationFromBr(item.ControlObject, param)));
+                    var distinctOrgs = result.AuditReports.Select(x => x.ControlObject).Distinct().ToList();
+                    brResults.AddRange(await GetOrganizationsFromBrBounded(distinctOrgs, param, logger));
                 }
-
-                var taskResult = Task.WhenAll(taskList);
-                try
-                {
-                    await taskResult;
-                }
-                catch (Exception)
-                {
-                    // Don't want one failed fetch to break the listing of the rest of the orgs
-                    if (taskResult.IsFaulted)
-                    {
-                        var failedTasks = taskList.Where(task => task.IsFaulted).ToList();
-                        foreach (var task in failedTasks)
-                        {
-                            logger.LogError(task.Exception, task.Exception?.Message);
-                        }
-
-                        taskList = taskList.Where(task => !task.IsFaulted).ToList();
-                    }
-                }
-
-                taskList = taskList
-                    .Where(task => task.Result is not null)
-                    .ToList();
-                brResults.AddRange(taskList.Select(t => t.Result));
             }
             catch (Exception ex)
             {

--- a/src/Dan.Plugin.Tilda/Functions/AuditReportFunctions.cs
+++ b/src/Dan.Plugin.Tilda/Functions/AuditReportFunctions.cs
@@ -158,7 +158,7 @@ public class AuditReportFunctions(
                 logger.LogError("Failed getting TilsynsRapportAlle org data for org {OrganizationNumber}: {message}", req.OrganizationNumber, ex.Message);
             }
 
-            var orgNumbers = brResults.Select(br => br.OrganizationNumber).ToList();
+            var orgNumbers = brResults.Select(br => br.OrganizationNumber).ToHashSet();
             result.AuditReports =
                 result.AuditReports?.Where(r => orgNumbers.Contains(r.ControlObject)).ToList();
         }

--- a/src/Dan.Plugin.Tilda/Functions/TrendReportFunctions.cs
+++ b/src/Dan.Plugin.Tilda/Functions/TrendReportFunctions.cs
@@ -142,39 +142,11 @@ public class TrendReportFunctions(
         {
             try
             {
-                var taskList = new List<Task<TildaRegistryEntry>>();
-
                 if (result.TrendReports != null)
                 {
-                    var distinctList = result.TrendReports.GroupBy(x => x.ControlObject).Select(y => y.FirstOrDefault()).ToList();
-                    taskList.AddRange(distinctList.Select(item => GetOrganizationFromBr(item.ControlObject, param)));
+                    var distinctOrgs = result.TrendReports.Select(x => x.ControlObject).Distinct().ToList();
+                    brResults.AddRange(await GetOrganizationsFromBrBounded(distinctOrgs, param, logger));
                 }
-
-                var taskResult = Task.WhenAll(taskList);
-                try
-                {
-                    await taskResult;
-                }
-                catch (Exception)
-                {
-                    // Don't want one failed fetch to break the listing of the rest of the orgs
-                    if (taskResult.IsFaulted)
-                    {
-                        var failedTasks = taskList.Where(task => task.IsFaulted).ToList();
-                        foreach (var task in failedTasks)
-                        {
-                            logger.LogError(task.Exception, "{message}", task.Exception?.Message);
-                        }
-                        taskList = taskList.Where(task => !task.IsFaulted).ToList();
-                    }
-                }
-                taskList = taskList
-                    .Where(task => task.Result is not null)
-                    .GroupBy(x => x.Result.OrganizationNumber)
-                    .Select(y => y.FirstOrDefault())
-                    .ToList();
-
-                brResults.AddRange(taskList.Select(t => t.Result));
             }
             catch (Exception ex)
             {

--- a/src/Dan.Plugin.Tilda/Functions/TrendReportFunctions.cs
+++ b/src/Dan.Plugin.Tilda/Functions/TrendReportFunctions.cs
@@ -153,7 +153,7 @@ public class TrendReportFunctions(
                 logger.LogError("Failed getting TrendRapportAlle org info for org {OrganizationNumber}: {message}", req.OrganizationNumber, ex.Message);
             }
 
-            var orgNumbers = brResults.Select(br => br.OrganizationNumber).ToList();
+            var orgNumbers = brResults.Select(br => br.OrganizationNumber).ToHashSet();
             result.TrendReports =
                 result.TrendReports?.Where(r => orgNumbers.Contains(r.ControlObject)).ToList();
         }

--- a/src/Dan.Plugin.Tilda/Program.cs
+++ b/src/Dan.Plugin.Tilda/Program.cs
@@ -5,9 +5,7 @@ using Dan.Plugin.Tilda;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Options;
 using Polly;
-using Polly.Extensions.Http;
 using Polly.Registry;
 using System;
 using System.Linq;
@@ -41,7 +39,9 @@ var host = new HostBuilder()
         var configurationRoot = context.Configuration;
         services.Configure<Settings>(configurationRoot);
 
-        var settings = services.BuildServiceProvider().GetRequiredService<IOptions<Settings>>().Value;
+        // Bind a local copy for use during service registration, without building an
+        // intermediate service provider (which would construct duplicate singletons)
+        var settings = configurationRoot.Get<Settings>();
 
         DefaultAzureCredential credentials = new();
         services.AddSingleton(credentials);
@@ -105,9 +105,6 @@ var host = new HostBuilder()
 
         services.AddSingleton<ITildaSourceProvider, TildaSourceProvider>();
 
-        var policyRegistry = services.BuildServiceProvider().GetRequiredService<IPolicyRegistry<string>>();
-        policyRegistry.Add("defaultCircuitBreaker", HttpPolicyExtensions.HandleTransientHttpError().CircuitBreakerAsync(4, TimeSpan.Parse(settings.Breaker_RetryWaitTime)));
-
         // Client configured without circuit breaker policies. shorter timeout
         services.AddHttpClient("ERHttpClient", client =>
         {
@@ -139,5 +136,12 @@ var host = new HostBuilder()
         });
     })
     .Build();
+
+// Dan.Common wires SafeHttpClient/PluginHttpClient with a single circuit breaker whose state is
+// shared across all upstream hosts, meaning a few failures from one tilsynsmyndighet would open
+// the circuit for every other source. Replace it with a no-op; failures are handled gracefully
+// per source (Failed status in GetData) and bounded by the SafeHttpClientTimeout app setting.
+host.Services.GetRequiredService<IPolicyRegistry<string>>()["SafeHttpClientPolicy"] =
+    Policy.NoOpAsync<HttpResponseMessage>();
 
 await host.RunAsync();

--- a/src/Dan.Plugin.Tilda/Program.cs
+++ b/src/Dan.Plugin.Tilda/Program.cs
@@ -106,12 +106,22 @@ var host = new HostBuilder()
 
         services.AddSingleton<ITildaSourceProvider, TildaSourceProvider>();
 
-        // Per-host circuit breaker on the data source client: each upstream authority
-        // (scheme://host:port) gets its own breaker state, so a failing tilsynsmyndighet
-        // fails fast without affecting calls to the other sources. Appends to Dan.Common's
-        // SafeHttpClient registration; its registry-based circuit breaker policy is replaced
-        // with a no-op after host build below.
+        // Appends to Dan.Common's SafeHttpClient registration (its registry-based circuit
+        // breaker policy is replaced with a no-op after host build below):
+        //
+        // - Pooled connection lifetime: TildaDataSource instances are captured by the singleton
+        //   TildaSourceProvider, so their HttpClients (and handler chains) live for the process
+        //   lifetime and the factory's handler rotation never applies. Recycling pooled
+        //   connections ensures upstream DNS changes (failover, traffic manager) are picked up.
+        //
+        // - Per-host circuit breaker: each upstream authority (scheme://host:port) gets its own
+        //   breaker state, so a failing tilsynsmyndighet fails fast without affecting calls to
+        //   the other sources.
         services.AddHttpClient("SafeHttpClient")
+            .ConfigurePrimaryHttpMessageHandler(() => new SocketsHttpHandler
+            {
+                PooledConnectionLifetime = TimeSpan.FromMinutes(5),
+            })
             .AddResilienceHandler("per-host-breaker", builder =>
             {
                 builder.AddCircuitBreaker(new HttpCircuitBreakerStrategyOptions
@@ -123,6 +133,13 @@ var host = new HostBuilder()
                 });
             })
             .SelectPipelineByAuthority();
+
+        // Also held for the process lifetime by the singleton-captured TildaDataSources
+        services.AddHttpClient("AlertHttpClient")
+            .ConfigurePrimaryHttpMessageHandler(() => new SocketsHttpHandler
+            {
+                PooledConnectionLifetime = TimeSpan.FromMinutes(5),
+            });
 
         // Client configured without circuit breaker policies. shorter timeout
         services.AddHttpClient("ERHttpClient", client =>

--- a/src/Dan.Plugin.Tilda/Program.cs
+++ b/src/Dan.Plugin.Tilda/Program.cs
@@ -5,6 +5,7 @@ using Dan.Plugin.Tilda;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Http.Resilience;
 using Polly;
 using Polly.Registry;
 using System;
@@ -105,6 +106,24 @@ var host = new HostBuilder()
 
         services.AddSingleton<ITildaSourceProvider, TildaSourceProvider>();
 
+        // Per-host circuit breaker on the data source client: each upstream authority
+        // (scheme://host:port) gets its own breaker state, so a failing tilsynsmyndighet
+        // fails fast without affecting calls to the other sources. Appends to Dan.Common's
+        // SafeHttpClient registration; its registry-based circuit breaker policy is replaced
+        // with a no-op after host build below.
+        services.AddHttpClient("SafeHttpClient")
+            .AddResilienceHandler("per-host-breaker", builder =>
+            {
+                builder.AddCircuitBreaker(new HttpCircuitBreakerStrategyOptions
+                {
+                    FailureRatio = 0.5,                          // open when >=50% of calls fail...
+                    MinimumThroughput = 8,                       // ...but only with enough samples (no tripping on a single blip)
+                    SamplingDuration = TimeSpan.FromSeconds(30), // failure ratio measured over this window
+                    BreakDuration = TimeSpan.FromSeconds(20),    // fail fast for 20s, then probe again
+                });
+            })
+            .SelectPipelineByAuthority();
+
         // Client configured without circuit breaker policies. shorter timeout
         services.AddHttpClient("ERHttpClient", client =>
         {
@@ -139,8 +158,9 @@ var host = new HostBuilder()
 
 // Dan.Common wires SafeHttpClient/PluginHttpClient with a single circuit breaker whose state is
 // shared across all upstream hosts, meaning a few failures from one tilsynsmyndighet would open
-// the circuit for every other source. Replace it with a no-op; failures are handled gracefully
-// per source (Failed status in GetData) and bounded by the SafeHttpClientTimeout app setting.
+// the circuit for every other source. Replace it with a no-op; the per-host circuit breaker
+// registered above provides fail-fast per upstream instead, and calls are bounded by the
+// SafeHttpClientTimeout app setting.
 host.Services.GetRequiredService<IPolicyRegistry<string>>()["SafeHttpClientPolicy"] =
     Policy.NoOpAsync<HttpResponseMessage>();
 

--- a/src/Dan.Plugin.Tilda/Services/BrregService.cs
+++ b/src/Dan.Plugin.Tilda/Services/BrregService.cs
@@ -44,7 +44,7 @@ public class BrregService(
         var result = new AccountsInformation();
         try
         {
-            var accountsUrl = $"http://data.brreg.no/regnskapsregisteret/regnskap/{organizationNumber}";
+            var accountsUrl = $"https://data.brreg.no/regnskapsregisteret/regnskap/{organizationNumber}";
             var cacheKey = $"Tilda-Cache_Absolute_GET_{accountsUrl}";
 
             try
@@ -64,6 +64,11 @@ public class BrregService(
 
 
             var response = await _safeHttpClient.GetAsync(accountsUrl);
+            if (!response.IsSuccessStatusCode)
+            {
+                return result;
+            }
+
             var rawResult = await response.Content.ReadAsStringAsync();
 
             var tmp = JsonConvert.DeserializeObject<JArray>(rawResult);

--- a/src/Dan.Plugin.Tilda/Services/BrregService.cs
+++ b/src/Dan.Plugin.Tilda/Services/BrregService.cs
@@ -63,7 +63,7 @@ public class BrregService(
             }
 
 
-            var response = await _safeHttpClient.GetAsync(accountsUrl);
+            using var response = await _safeHttpClient.GetAsync(accountsUrl);
             if (!response.IsSuccessStatusCode)
             {
                 return result;

--- a/src/Dan.Plugin.Tilda/Services/FilterService.cs
+++ b/src/Dan.Plugin.Tilda/Services/FilterService.cs
@@ -37,9 +37,14 @@ public class FilterService : IFilterService
             return resultList;
         }
 
+        var enkOrgs = orgs
+            .Where(x => x.OrganisationForm == "ENK")
+            .Select(x => x.OrganizationNumber)
+            .ToHashSet();
+
         bool IsEnk(string orgNo)
         {
-            return orgs.Any(x => x.OrganizationNumber == orgNo && x.OrganisationForm == "ENK");
+            return enkOrgs.Contains(orgNo);
         }
 
         switch (resultList)


### PR DESCRIPTION
## Summary

Addresses the findings from a performance/concurrency review of the plugin's hot path (evidence requests fanning out to ~26 tilsynsmyndighet APIs + Brreg/Kofuvi, behind Redis caching). The changes remove the main per-instance throughput ceilings: blocking Key Vault calls on the request path, unbounded outbound fan-out, allocation pressure from large JSON payloads, and a failure-amplifying shared circuit breaker.

## Changes

### Key Vault certificate caching (34bedce)
The `KofuviCertificate`/`DigdirCertificate` getters used `??` without assigning the backing field, so **every** access performed a new Key Vault round trip with sync-over-async blocking (`.Result`) - including one per Maskinporten token call. Now cached after first fetch (`??=`).

### Bounded BR fan-out (34bedce)
The `*Alle` functions with geo search spawned one org-info lookup per distinct control object with no concurrency limit - a monthly report could fire thousands of simultaneous outbound calls (SNAT exhaustion, Brreg rate limiting). Replaced with a shared `GetOrganizationsFromBrBounded` helper (`Parallel.ForEachAsync`, max 16 concurrent), preserving the skip-failed-lookups behavior. Net -96 lines across the three call sites.

### Parallel independent lookups + timeout status (69ea8d5)
- Annual turnover and Kofuvi address lookups are independent; they now run concurrently instead of sequentially (saves a round trip per org, multiplied by the fan-out).
- `GetData` left the result status unset on timeout, so a timed-out source could be mistaken for a valid empty result downstream. Timeouts now report `StatusEnum.Failed`.

### Circuit breaker rework (cacdce7, 660f073)
Dan.Common wires `SafeHttpClient` with a single circuit breaker whose state is shared across **all** upstream hosts - a few failures from one tilsynsmyndighet opened the circuit for every source. Changes:
- Replace the shared registry policy with a no-op after host build
- Add a per-host circuit breaker via `Microsoft.Extensions.Http.Resilience` with `SelectPipelineByAuthority()`: ratio-based tripping (>=50% failures over 30s, min 8 samples, 20s break), so a dead source fails fast without dragging every response to the timeout floor or affecting healthy sources
- Remove the unused `defaultCircuitBreaker` policy registration and `Breaker_*` settings (nothing read them)
- Remove both `BuildServiceProvider()`-during-registration anti-patterns; settings are bound directly from configuration

Production timeout is controlled by the existing `SafeHttpClientTimeout` app setting (Dan.Common default 30s) - set deliberately after checking per-source `elapsedMs` percentiles.

### Allocation pressure (6260efb)
- Data source responses are deserialized from the buffered response stream instead of materializing the whole body as a string first; `*Alle` payloads were large enough that the intermediate string (~2x payload size) landed on the large object heap on every request. Buffered send is kept deliberately so `HttpClient.Timeout` still covers the body download. Responses are now disposed.
- Enable Server GC - isolated workers are console apps and default to workstation GC.

### Connection recycling + quadratic filters (2ef86fc)
- `TildaDataSource` instances are captured by the singleton `TildaSourceProvider`, so their `HttpClient`s never rotate handlers and upstream DNS changes were never picked up. `SafeHttpClient`/`AlertHttpClient` now recycle pooled connections every 5 minutes (one TLS handshake per host per window).
- Org-number filtering in the `*Alle` functions and ENK filtering in `FilterService` were O(orgs x reports) per request; now `HashSet` lookups.
- Regnskapsregisteret fetch: `https://` (avoids a redirect per cache miss) and early return on non-success.

## Behavior notes

- A source whose breaker is open reports `Failed` for that source only; the other sources respond normally
- The regnskap cache keys change with the URL scheme, so those Redis entries go cold once after deploy
- Server GC trades memory for throughput - worth a glance at working set after rollout
- Azure app settings `Breaker_RetryWaitTime`, `Breaker_OpenCircuitTime`, `DefaultCircuitBreaker*` become inert and can be removed

## Test plan

- [x] `dotnet build` clean
- [x] `dotnet test` 13/13 passing (per commit)
- [ ] Verify in test environment: one failing source yields per-source `Failed` status without affecting other sources
- [ ] Set `SafeHttpClientTimeout` app setting for prod after checking per-source latency percentiles in App Insights

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Bounded concurrent lookups for organization metadata
  * Cached certificate retrieval for faster repeated access
  * More efficient filtering logic

* **Reliability**
  * Safer HTTP response handling and explicit disposal of responses
  * Clearer timeout messages and improved error logging

* **Security**
  * Switched external service calls to HTTPS

* **Infrastructure**
  * Updated HTTP resilience configuration and enabled server-optimized GC
<!-- end of auto-generated comment: release notes by coderabbit.ai -->