### PR TITLE
Treat brreg failures as non-fatal, fail closed on filtering

### DIFF
--- a/src/Dan.Plugin.Tilda/Functions/AuditCoordinationFunctions.cs
+++ b/src/Dan.Plugin.Tilda/Functions/AuditCoordinationFunctions.cs
@@ -54,7 +54,7 @@ public class AuditCoordinationFunctions(
 
     private async Task<List<EvidenceValue>> GetEvidenceValuesTilsynskoordinering(EvidenceHarvesterRequest req, TildaParameters param)
     {
-        var brResultTask = GetOrganizationsFromBr(req.OrganizationNumber);
+        var brResultTask = GetOrganizationsFromBr(req.OrganizationNumber, logger);
 
         var taskList = new List<Task<AuditCoordinationList>>();
         try
@@ -71,6 +71,7 @@ public class AuditCoordinationFunctions(
 
         await Task.WhenAll(taskList);
         var brResult = await brResultTask;
+        var orgs = brResult.Organizations;
         var list = new List<AuditCoordinationList>();
 
         foreach (var values in taskList.Select(task => task.Result))
@@ -87,10 +88,10 @@ public class AuditCoordinationFunctions(
         }
 
         var ecb = new EvidenceBuilder(metadata, "TildaTilsynskoordineringv1");
-        foreach (var unit in brResult)
+        foreach (var unit in orgs)
             ecb.AddEvidenceValue("enhetsinformasjon", JsonConvert.SerializeObject(unit), "Enhetsregisteret", false);
 
-        foreach (var filtered in list.Select(a => (AuditCoordinationList)filterService.FilterAuditList(a, brResult)))
+        foreach (var filtered in list.Select(a => (AuditCoordinationList)filterService.FilterAuditList(a, orgs, brResult.OrgInfoUnavailable)))
         {
             ecb.AddEvidenceValue("tilsynskoordineringer", JsonConvert.SerializeObject(filtered, Formatting.None), filtered.ControlAgency, false);
         }

--- a/src/Dan.Plugin.Tilda/Functions/AuditFunctionsBase.cs
+++ b/src/Dan.Plugin.Tilda/Functions/AuditFunctionsBase.cs
@@ -120,28 +120,50 @@ public abstract class AuditFunctionsBase(IBrregService brregService)
             .ToList();
     }
 
-    protected async Task<List<TildaRegistryEntry>> GetOrganizationsFromBr(string organizationNumber)
+    /// <summary>
+    /// Result of looking up the requestor's organization info from BR. Org info is added-value
+    /// enrichment, not critical, so a failed/timed-out lookup must never fail the whole request.
+    /// When <see cref="OrgInfoUnavailable"/> is true the caller must fail closed in filtering: we
+    /// can't tell whether the org is an ENK, so protected fields are stripped rather than exposed.
+    /// </summary>
+    protected sealed record BrOrganizationsResult(List<TildaRegistryEntry> Organizations, bool OrgInfoUnavailable);
+
+    protected async Task<BrOrganizationsResult> GetOrganizationsFromBr(string organizationNumber, ILogger logger = null)
     {
-        var result = new List<TildaRegistryEntry>();
-        var brResult = await brregService.GetFromBr(organizationNumber, false);
-        var brEntity = brResult.First();
-
-        // Annual turnover and kofuvi addresses are independent lookups, fetch them in parallel
-        var accountsTask = string.IsNullOrEmpty(brEntity.OverordnetEnhet) && brEntity.Organisasjonsform?.Kode != "ENK"
-            ? brregService.GetAnnualTurnoverFromBr(organizationNumber)
-            : Task.FromResult<AccountsInformation>(null);
-        var kofuviTask = brregService.GetKofuviAddresses(organizationNumber);
-        await Task.WhenAll(accountsTask, kofuviTask);
-        var accountsInformation = accountsTask.Result;
-        var kofuviAddresses = kofuviTask.Result;
-
-        var organization = ConvertBRtoTilda(brEntity, accountsInformation);
-        if (kofuviAddresses.Count > 0)
+        try
         {
-            organization.Emails = kofuviAddresses;
+            var brResult = await brregService.GetFromBr(organizationNumber, false);
+            var brEntity = brResult.FirstOrDefault();
+            if (brEntity is null)
+            {
+                return new BrOrganizationsResult([], OrgInfoUnavailable: true);
+            }
+
+            // Annual turnover and kofuvi addresses are independent lookups, fetch them in parallel
+            var accountsTask = string.IsNullOrEmpty(brEntity.OverordnetEnhet) && brEntity.Organisasjonsform?.Kode != "ENK"
+                ? brregService.GetAnnualTurnoverFromBr(organizationNumber)
+                : Task.FromResult<AccountsInformation>(null);
+            var kofuviTask = brregService.GetKofuviAddresses(organizationNumber);
+            await Task.WhenAll(accountsTask, kofuviTask);
+            var accountsInformation = accountsTask.Result;
+            var kofuviAddresses = kofuviTask.Result;
+
+            var organization = ConvertBRtoTilda(brEntity, accountsInformation);
+            if (kofuviAddresses.Count > 0)
+            {
+                organization.Emails = kofuviAddresses;
+            }
+            return new BrOrganizationsResult([organization], OrgInfoUnavailable: false);
         }
-        result.Add(organization);
-        return result;
+        catch (Exception ex)
+        {
+            // BR org info is added-value enrichment, not critical: never fail the whole request on
+            // its account (e.g. an ERHttpClient timeout throws TaskCanceledException here). Signal
+            // that org info is unavailable so filtering fails closed.
+            logger?.LogError(ex, "Failed getting org info from BR for org {OrganizationNumber}: {message}",
+                organizationNumber, ex.Message);
+            return new BrOrganizationsResult([], OrgInfoUnavailable: true);
+        }
     }
 
     private TildaRegistryEntry ConvertBRtoTilda(BREntityRegisterEntry brResult, AccountsInformation accountsInformation)

--- a/src/Dan.Plugin.Tilda/Functions/AuditReportFunctions.cs
+++ b/src/Dan.Plugin.Tilda/Functions/AuditReportFunctions.cs
@@ -54,7 +54,7 @@ public class AuditReportFunctions(
 
     private async Task<List<EvidenceValue>> GetEvidenceValuesTilsynsrapport(EvidenceHarvesterRequest req, TildaParameters param)
     {
-        var brResultTask = GetOrganizationsFromBr(req.OrganizationNumber);
+        var brResultTask = GetOrganizationsFromBr(req.OrganizationNumber, logger);
 
         var taskList = new List<Task<AuditReportList>>();
         try
@@ -72,6 +72,7 @@ public class AuditReportFunctions(
 
         await Task.WhenAll(taskList);
         var brResult = await brResultTask;
+        var orgs = brResult.Organizations;
         var list = new List<AuditReportList>();
 
         foreach (var values in taskList.Select(task => task.Result))
@@ -89,14 +90,14 @@ public class AuditReportFunctions(
 
         var ecb = new EvidenceBuilder(metadata, "TildaTilsynsrapportv1");
 
-        foreach (var unit in brResult)
+        foreach (var unit in orgs)
         {
             ecb.AddEvidenceValue("enhetsinformasjon", JsonConvert.SerializeObject(unit), "Enhetsregisteret", false);
         }
 
         foreach (var a in list)
         {
-            var filtered = (AuditReportList)filterService.FilterAuditList(a, brResult);
+            var filtered = (AuditReportList)filterService.FilterAuditList(a, orgs, brResult.OrgInfoUnavailable);
             ecb.AddEvidenceValue($"tilsynsrapporter", JsonConvert.SerializeObject(filtered, Formatting.None), a.ControlAgency, false);
         }
 

--- a/src/Dan.Plugin.Tilda/Functions/NpdidFunctions.cs
+++ b/src/Dan.Plugin.Tilda/Functions/NpdidFunctions.cs
@@ -41,7 +41,7 @@ public class NpdidFunctions(
 
     private async Task<List<EvidenceValue>> GetEvidenceValuesNpdid(EvidenceHarvesterRequest req, TildaParameters param)
     {
-        var brResultTask = GetOrganizationsFromBr(req.OrganizationNumber);
+        var brResultTask = GetOrganizationsFromBr(req.OrganizationNumber, logger);
 
         var taskList = new List<Task<NpdidAuditReportList>>();
         try
@@ -59,6 +59,7 @@ public class NpdidFunctions(
 
         await Task.WhenAll(taskList);
         var brResult = await brResultTask;
+        var orgs = brResult.Organizations;
         var list = new List<NpdidAuditReportList>();
 
         foreach (var task in taskList)
@@ -78,13 +79,13 @@ public class NpdidFunctions(
 
         var ecb = new EvidenceBuilder(metadata, "TildaNPDIDv1");
 
-        foreach (var unit in brResult)
+        foreach (var unit in orgs)
             ecb.AddEvidenceValue("enhetsinformasjon", JsonConvert.SerializeObject(unit), "Enhetsregisteret", false);
         try
         {
             foreach (var a in list)
             {
-                var filtered = (NpdidAuditReportList)filterService.FilterAuditList(a, brResult);
+                var filtered = (NpdidAuditReportList)filterService.FilterAuditList(a, orgs, brResult.OrgInfoUnavailable);
                 ecb.AddEvidenceValue("tilsynsrapporter", JsonConvert.SerializeObject(filtered, Formatting.None), a.ControlAgency, false);
             }
         }

--- a/src/Dan.Plugin.Tilda/Functions/TrendReportFunctions.cs
+++ b/src/Dan.Plugin.Tilda/Functions/TrendReportFunctions.cs
@@ -54,7 +54,7 @@ public class TrendReportFunctions(
 
     private async Task<List<EvidenceValue>> GetEvidenceValuesTrend(EvidenceHarvesterRequest req, TildaParameters param)
     {
-        var brResultTask = GetOrganizationsFromBr(req.OrganizationNumber);
+        var brResultTask = GetOrganizationsFromBr(req.OrganizationNumber, logger);
 
         var taskList = new List<Task<TrendReportList>>();
         try
@@ -71,6 +71,7 @@ public class TrendReportFunctions(
 
         await Task.WhenAll(taskList);
         var brResult = await brResultTask;
+        var orgs = brResult.Organizations;
         var list = new List<TrendReportList>();
 
         foreach (var values in taskList.Select(task => task.Result))
@@ -88,14 +89,14 @@ public class TrendReportFunctions(
 
         var ecb = new EvidenceBuilder(metadata, "TildaTrendrapportv1");
 
-        foreach (var unit in brResult)
+        foreach (var unit in orgs)
         {
             ecb.AddEvidenceValue("enhetsinformasjon", JsonConvert.SerializeObject(unit), "Enhetsregisteret", false);
         }
 
         foreach (var a in list)
         {
-            var filtered = (TrendReportList)filterService.FilterAuditList(a, brResult);
+            var filtered = (TrendReportList)filterService.FilterAuditList(a, orgs, brResult.OrgInfoUnavailable);
             ecb.AddEvidenceValue($"tilsynstrendrapporter", JsonConvert.SerializeObject(filtered, Formatting.None), a.ControlAgency, false);
         }
 

--- a/src/Dan.Plugin.Tilda/Program.cs
+++ b/src/Dan.Plugin.Tilda/Program.cs
@@ -142,9 +142,12 @@ var host = new HostBuilder()
             });
 
         // Client configured without circuit breaker policies. shorter timeout
+        // brreg's enhetsregisteret normally responds in ~200ms; 10s only trips on a genuine
+        // stall, and a stall here is non-fatal (org info is added-value enrichment, see
+        // AuditFunctionsBase.GetOrganizationsFromBr).
         services.AddHttpClient("ERHttpClient", client =>
         {
-            client.Timeout = new TimeSpan(0, 0, 5);
+            client.Timeout = new TimeSpan(0, 0, 10);
         });
 
         services.AddHttpClient("KofuviClient", client =>

--- a/src/Dan.Plugin.Tilda/Services/BrregService.cs
+++ b/src/Dan.Plugin.Tilda/Services/BrregService.cs
@@ -49,10 +49,12 @@ public class BrregService(
 
             try
             {
-                result = await cache.GetValueAsync<AccountsInformation>(cacheKey);
-                if (result is not null)
+                // Don't assign into `result`: a cache miss returns null and would clobber the
+                // empty AccountsInformation the failure paths below return.
+                var cached = await cache.GetValueAsync<AccountsInformation>(cacheKey);
+                if (cached is not null)
                 {
-                    return result;
+                    return cached;
                 }
             }
             catch (Exception e)

--- a/src/Dan.Plugin.Tilda/Services/FilterService.cs
+++ b/src/Dan.Plugin.Tilda/Services/FilterService.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Dan.Plugin.Tilda.Models;
 using Dan.Tilda.Models.Audits;
@@ -12,12 +13,12 @@ namespace Dan.Plugin.Tilda.Services;
 
 public interface IFilterService
 {
-    IAuditList FilterAuditList(IAuditList resultList, List<TildaRegistryEntry> orgs);
+    IAuditList FilterAuditList(IAuditList resultList, List<TildaRegistryEntry> orgs, bool orgInfoUnavailable = false);
 }
 
 public class FilterService : IFilterService
 {
-    public IAuditList FilterAuditList(IAuditList resultList, List<TildaRegistryEntry> orgs)
+    public IAuditList FilterAuditList(IAuditList resultList, List<TildaRegistryEntry> orgs, bool orgInfoUnavailable = false)
     {
         // *** TEMPORARY TILDA FILTERING ***
         // We need to temporarily remove _all_ data from the result list if orgForm is ENK
@@ -25,26 +26,35 @@ public class FilterService : IFilterService
         // - remove meldingTilAnnenMyndighet
         // - remove tilsynsnotater
         // - remove kontaktperson name
-        if (orgs == null || orgs.Count == 0)
+        Func<string, bool> IsEnk;
+
+        if (orgInfoUnavailable)
         {
-            return resultList;
+            // Fail closed: we couldn't determine org forms from BR (e.g. a timeout), so we can't
+            // tell which control objects are ENK. Treat every one as ENK and strip protected
+            // fields rather than risk exposing an ENK's data.
+            IsEnk = _ => true;
         }
-
-        var firstOrg = orgs.First();
-        // If first organization is a specific test organization, disable filtering
-        if (firstOrg.OrganizationNumber == "111111111")
+        else
         {
-            return resultList;
-        }
+            if (orgs == null || orgs.Count == 0)
+            {
+                return resultList;
+            }
 
-        var enkOrgs = orgs
-            .Where(x => x.OrganisationForm == "ENK")
-            .Select(x => x.OrganizationNumber)
-            .ToHashSet();
+            var firstOrg = orgs.First();
+            // If first organization is a specific test organization, disable filtering
+            if (firstOrg.OrganizationNumber == "111111111")
+            {
+                return resultList;
+            }
 
-        bool IsEnk(string orgNo)
-        {
-            return enkOrgs.Contains(orgNo);
+            var enkOrgs = orgs
+                .Where(x => x.OrganisationForm == "ENK")
+                .Select(x => x.OrganizationNumber)
+                .ToHashSet();
+
+            IsEnk = enkOrgs.Contains;
         }
 
         switch (resultList)

--- a/test/Dan.Plugin.Tilda.Test/Services/BrregServiceTests.cs
+++ b/test/Dan.Plugin.Tilda.Test/Services/BrregServiceTests.cs
@@ -1,0 +1,162 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Dan.Common.Exceptions;
+using Dan.Plugin.Tilda.Config;
+using Dan.Plugin.Tilda.Services;
+using FakeItEasy;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Dan.Plugin.Tilda.Test.Services;
+
+public class BrregServiceTests
+{
+    // Not one of the hardcoded TEST orgs (111111111 / 811105562) that GetFromBr short-circuits.
+    private const string OrgNo = "999999999";
+
+    private readonly IDistributedCache _cache = A.Fake<IDistributedCache>();
+    private readonly IOptions<Settings> _settings = A.Fake<IOptions<Settings>>();
+    private readonly ILogger<BrregService> _logger = A.Fake<ILogger<BrregService>>();
+
+    public BrregServiceTests()
+    {
+        A.CallTo(() => _settings.Value).Returns(new Settings { KofuviEndpoint = "https://kofuvi.test" });
+
+        // Always a cache miss, so every call exercises the (stubbed) HTTP layer.
+        A.CallTo(() => _cache.GetAsync(A<string>._, A<CancellationToken>._))
+            .Returns(Task.FromResult<byte[]?>(null));
+    }
+
+    private BrregService CreateService(Func<HttpRequestMessage, HttpResponseMessage> responder)
+    {
+        var client = new HttpClient(new StubHttpMessageHandler(responder));
+        var factory = A.Fake<IHttpClientFactory>();
+        // BrregService builds SafeHttpClient/ERHttpClient/KofuviClient; each test exercises one.
+        A.CallTo(() => factory.CreateClient(A<string>._)).Returns(client);
+        return new BrregService(factory, _cache, _settings, _logger);
+    }
+
+    // --- GetKofuviAddresses: soft + hard fails both degrade gracefully to an empty list ---
+
+    [Fact]
+    public async Task GetKofuviAddresses_SoftFail_NonSuccessStatus_ReturnsEmptyWithoutThrowing()
+    {
+        var sut = CreateService(_ => new HttpResponseMessage(HttpStatusCode.ServiceUnavailable));
+
+        var result = await sut.GetKofuviAddresses(OrgNo);
+
+        result.Should().NotBeNull().And.BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetKofuviAddresses_SoftFail_NotFound_ReturnsEmptyWithoutThrowing()
+    {
+        var sut = CreateService(_ => new HttpResponseMessage(HttpStatusCode.NotFound));
+
+        var result = await sut.GetKofuviAddresses(OrgNo);
+
+        result.Should().NotBeNull().And.BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetKofuviAddresses_HardFail_RequestException_ReturnsEmptyWithoutThrowing()
+    {
+        var sut = CreateService(_ => throw new HttpRequestException("connection refused"));
+
+        var result = await sut.GetKofuviAddresses(OrgNo);
+
+        result.Should().NotBeNull().And.BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetKofuviAddresses_HardFail_Timeout_ReturnsEmptyWithoutThrowing()
+    {
+        var sut = CreateService(_ => throw new TaskCanceledException("timeout", new TimeoutException()));
+
+        var result = await sut.GetKofuviAddresses(OrgNo);
+
+        result.Should().NotBeNull().And.BeEmpty();
+    }
+
+    // --- GetAnnualTurnoverFromBr: soft + hard fails both degrade to an empty AccountsInformation
+    // (no throw, no turnover data). ---
+
+    [Fact]
+    public async Task GetAnnualTurnoverFromBr_SoftFail_NonSuccessStatus_ReturnsEmptyWithoutThrowing()
+    {
+        var sut = CreateService(_ => new HttpResponseMessage(HttpStatusCode.InternalServerError));
+
+        var result = await sut.GetAnnualTurnoverFromBr(OrgNo);
+
+        result.Should().NotBeNull();
+        result.AnnualTurnover.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetAnnualTurnoverFromBr_HardFail_Timeout_ReturnsEmptyWithoutThrowing()
+    {
+        var sut = CreateService(_ => throw new TaskCanceledException("timeout", new TimeoutException()));
+
+        var result = await sut.GetAnnualTurnoverFromBr(OrgNo);
+
+        result.Should().NotBeNull();
+        result.AnnualTurnover.Should().BeNull();
+    }
+
+    // --- GetFromBr / GetOrganizationInfoFromBr: fails surface as exceptions for the caller ---
+
+    [Fact]
+    public async Task GetFromBr_SoftFail_NotFound_ThrowsPermanentClientException()
+    {
+        // 404 on both main unit and sub unit => organization genuinely not found.
+        var sut = CreateService(_ => new HttpResponseMessage(HttpStatusCode.NotFound));
+
+        var act = async () => await sut.GetFromBr(OrgNo, includeSubunits: false);
+
+        await act.Should().ThrowAsync<EvidenceSourcePermanentClientException>();
+    }
+
+    [Fact]
+    public async Task GetFromBr_HardFail_RequestException_ThrowsPermanentServerException()
+    {
+        var sut = CreateService(_ => throw new HttpRequestException("dns failure"));
+
+        var act = async () => await sut.GetFromBr(OrgNo, includeSubunits: false);
+
+        await act.Should().ThrowAsync<EvidenceSourcePermanentServerException>();
+    }
+
+    [Fact]
+    public async Task GetFromBr_HardFail_Timeout_PropagatesToCaller()
+    {
+        // Contract: BrregService does NOT translate HttpClient timeouts. The caller
+        // (AuditFunctionsBase.GetOrganizationsFromBr) catches them and fails closed, so the
+        // exception must escape here rather than being swallowed into a "found nothing" result.
+        var sut = CreateService(_ => throw new TaskCanceledException("timeout", new TimeoutException()));
+
+        var act = async () => await sut.GetFromBr(OrgNo, includeSubunits: false);
+
+        await act.Should().ThrowAsync<TaskCanceledException>();
+    }
+
+    private sealed class StubHttpMessageHandler(Func<HttpRequestMessage, HttpResponseMessage> responder)
+        : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            try
+            {
+                return Task.FromResult(responder(request));
+            }
+            catch (Exception ex)
+            {
+                return Task.FromException<HttpResponseMessage>(ex);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Problem

Recurring production error: `TaskCanceledException` — "The request was canceled due to the configured HttpClient.Timeout of 5 seconds elapsing" — surfacing as an unhandled **Error** and failing the whole evidence request.

Root cause: `BrregService.GetOrganizationInfoFromBr` (the `ERHttpClient`, 5s timeout) only caught `HttpRequestException`. An `HttpClient.Timeout` raises `TaskCanceledException`, which slipped past, propagated up through the singular `GetOrganizationsFromBr` → the function → `EvidenceSourceResponse.CreateResponse`, and failed the request. It happens when brreg's enhetsregisteret takes >5s, typically on a Redis cache miss.

Brreg org info is **added-value enrichment, not critical** — a brreg failure should never fail the request. But the same data drives `FilterService`'s ENK/GDPR stripping, so we must **fail closed** when org form is unknown.

## Changes

- **`AuditFunctionsBase.GetOrganizationsFromBr`** no longer throws: returns `BrOrganizationsResult(Organizations, OrgInfoUnavailable)` and logs the failure. A brreg problem now degrades instead of failing the request.
- **`FilterService`** fails closed when org info is unavailable: it can no longer tell which control objects are ENK, so it strips protected fields for all rather than returning them unfiltered (avoids leaking an ENK's data during a brreg outage). Threaded through all four non-`Alle` callers (AuditReport / Coordination / Trend / Npdid).
- **`ERHttpClient`** timeout raised 5s → 10s; brreg normally responds in ~200ms, so 10s only trips on a genuine stall.
- **`GetAnnualTurnoverFromBr`** now returns an empty `AccountsInformation` on failure instead of null (a cache miss was clobbering the initialized result).

## Tests

Adds `BrregServiceTests` covering soft (non-success status) and hard (exception / timeout) failures across both the graceful-degradation methods (`GetKofuviAddresses`, `GetAnnualTurnoverFromBr`) and the throwing path (`GetFromBr` → not-found / upstream-error / timeout-propagates). Full suite: 22 passing.

## Note on `*Alle` paths

Geo-search (`*Alle`) paths already degrade per-org via `GetOrganizationsFromBrBounded`, so they keep the default `orgInfoUnavailable: false`. Side effect of fail-closed: during a brreg outage Trend reports come back empty (safe, but aggressive) — flagged for awareness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added fail-closed handling for unavailable organization information to ensure consistent behavior

* **Bug Fixes**
  * Fixed organization information not being preserved when cache lookups miss

* **Performance & Reliability**
  * Increased HTTP client timeout from 5 to 10 seconds for improved stability

* **Tests**
  * Added comprehensive test suite covering error handling and timeout scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->