### PR TITLE
Bound all HTTP connection pools to fix socket exhaustion

### DIFF
--- a/src/Dan.Plugin.Tilda/Program.cs
+++ b/src/Dan.Plugin.Tilda/Program.cs
@@ -106,6 +106,16 @@ var host = new HostBuilder()
 
         services.AddSingleton<ITildaSourceProvider, TildaSourceProvider>();
 
+        // Per-host connection cap shared by every outbound pool below. WSAENOBUFS ("system lacked
+        // sufficient buffer space") is a process-global socket-buffer limit, so it surfaces on
+        // whichever host the worker happens to be dialing when buffers run dry (seen on both
+        // data.brreg.no and maskinporten.no). The per-request fan-out (~26 sources + bounded BR
+        // enrichment) caps a single request, but nothing bounded the pools across concurrent
+        // requests: without this, in-flight requests open connections without limit until the
+        // worker exhausts its buffers. Capping per host turns cross-request overload into
+        // backpressure (requests wait for a free connection) instead of socket exhaustion.
+        const int maxConnectionsPerHost = 50;
+
         // Appends to Dan.Common's SafeHttpClient registration (its registry-based circuit
         // breaker policy is replaced with a no-op after host build below):
         //
@@ -121,6 +131,7 @@ var host = new HostBuilder()
             .ConfigurePrimaryHttpMessageHandler(() => new SocketsHttpHandler
             {
                 PooledConnectionLifetime = TimeSpan.FromMinutes(5),
+                MaxConnectionsPerServer = maxConnectionsPerHost,
             })
             .AddResilienceHandler("per-host-breaker", builder =>
             {
@@ -139,6 +150,20 @@ var host = new HostBuilder()
             .ConfigurePrimaryHttpMessageHandler(() => new SocketsHttpHandler
             {
                 PooledConnectionLifetime = TimeSpan.FromMinutes(5),
+                MaxConnectionsPerServer = maxConnectionsPerHost,
+            });
+
+        // Default (unnamed) factory client. The singleton MaskinportenService takes a plain
+        // HttpClient (its single _client field), which the factory resolves to the default-named
+        // client; that is the pool used for token requests to maskinporten.no. Without this it
+        // would use the factory's default handler: unbounded MaxConnectionsPerServer and, because
+        // the service is a captured singleton, a handler that never recycles (stale DNS on
+        // failover). Bound and recycle it like the rest.
+        services.AddHttpClient(string.Empty)
+            .ConfigurePrimaryHttpMessageHandler(() => new SocketsHttpHandler
+            {
+                PooledConnectionLifetime = TimeSpan.FromMinutes(5),
+                MaxConnectionsPerServer = maxConnectionsPerHost,
             });
 
         // Client configured without circuit breaker policies. shorter timeout
@@ -148,6 +173,11 @@ var host = new HostBuilder()
         services.AddHttpClient("ERHttpClient", client =>
         {
             client.Timeout = new TimeSpan(0, 0, 10);
+        })
+        .ConfigurePrimaryHttpMessageHandler(() => new SocketsHttpHandler
+        {
+            PooledConnectionLifetime = TimeSpan.FromMinutes(5),
+            MaxConnectionsPerServer = maxConnectionsPerHost,
         });
 
         services.AddHttpClient("KofuviClient", client =>
@@ -156,7 +186,7 @@ var host = new HostBuilder()
             })
         .ConfigurePrimaryHttpMessageHandler(() =>
         {
-            var handler = new HttpClientHandler();
+            var handler = new HttpClientHandler { MaxConnectionsPerServer = maxConnectionsPerHost };
             handler.ClientCertificates.Add(Settings.KofuviCertificate);
             return handler;
         });

--- a/src/Dan.Plugin.Tilda/Program.cs
+++ b/src/Dan.Plugin.Tilda/Program.cs
@@ -106,14 +106,10 @@ var host = new HostBuilder()
 
         services.AddSingleton<ITildaSourceProvider, TildaSourceProvider>();
 
-        // Per-host connection cap shared by every outbound pool below. WSAENOBUFS ("system lacked
-        // sufficient buffer space") is a process-global socket-buffer limit, so it surfaces on
-        // whichever host the worker happens to be dialing when buffers run dry (seen on both
-        // data.brreg.no and maskinporten.no). The per-request fan-out (~26 sources + bounded BR
-        // enrichment) caps a single request, but nothing bounded the pools across concurrent
-        // requests: without this, in-flight requests open connections without limit until the
-        // worker exhausts its buffers. Capping per host turns cross-request overload into
-        // backpressure (requests wait for a free connection) instead of socket exhaustion.
+        // Per-host cap shared by every pool below. The per-request fan-out is bounded, but nothing
+        // bounded the pools across concurrent requests, so connections grew without limit until the
+        // worker hit WSAENOBUFS (process-global socket-buffer exhaustion, seen on both data.brreg.no
+        // and maskinporten.no). Capping per host gives backpressure instead.
         const int maxConnectionsPerHost = 50;
 
         // Appends to Dan.Common's SafeHttpClient registration (its registry-based circuit
@@ -153,12 +149,9 @@ var host = new HostBuilder()
                 MaxConnectionsPerServer = maxConnectionsPerHost,
             });
 
-        // Default (unnamed) factory client. The singleton MaskinportenService takes a plain
-        // HttpClient (its single _client field), which the factory resolves to the default-named
-        // client; that is the pool used for token requests to maskinporten.no. Without this it
-        // would use the factory's default handler: unbounded MaxConnectionsPerServer and, because
-        // the service is a captured singleton, a handler that never recycles (stale DNS on
-        // failover). Bound and recycle it like the rest.
+        // Default (unnamed) client: the singleton MaskinportenService's plain HttpClient resolves
+        // to this, so it's the pool for maskinporten.no token requests. Bound and recycle it like
+        // the rest (otherwise unbounded, and its singleton-captured handler never refreshes DNS).
         services.AddHttpClient(string.Empty)
             .ConfigurePrimaryHttpMessageHandler(() => new SocketsHttpHandler
             {

--- a/src/Dan.Plugin.Tilda/Services/BrregService.cs
+++ b/src/Dan.Plugin.Tilda/Services/BrregService.cs
@@ -258,8 +258,7 @@ public class BrregService(
             {
                 if (response.StatusCode == HttpStatusCode.NotFound)
                 {
-                    // Dispose the main-unit response before replacing it so its connection
-                    // is returned to the pool rather than leaking under the fan-out load.
+                    // Dispose before replacing so the connection returns to the pool, not leaks.
                     response.Dispose();
                     response = await _erClient.GetAsync(subUnitUrl);
                     if (response.StatusCode == HttpStatusCode.NotFound)

--- a/src/Dan.Plugin.Tilda/Services/BrregService.cs
+++ b/src/Dan.Plugin.Tilda/Services/BrregService.cs
@@ -151,7 +151,7 @@ public class BrregService(
         string responseString;
         try
         {
-            var response = await _kofuviClient.GetAsync(targetUrl);
+            using var response = await _kofuviClient.GetAsync(targetUrl);
             if (!response.IsSuccessStatusCode)
             {
                 //skip logging 404 - just means there are no addresses for this organization and clutters logs
@@ -254,18 +254,28 @@ public class BrregService(
             }
 
             var response = await _erClient.GetAsync(mainUnitUrl);
-            if (response.StatusCode == HttpStatusCode.NotFound)
+            try
             {
-                response = await _erClient.GetAsync(subUnitUrl);
                 if (response.StatusCode == HttpStatusCode.NotFound)
                 {
-                    throw new EvidenceSourcePermanentClientException(
-                        Metadata.ERROR_ORGANIZATION_NOT_FOUND,
-                        $"{organizationNumber} was not found in the Central Coordinating Register for Legal Entities");
+                    // Dispose the main-unit response before replacing it so its connection
+                    // is returned to the pool rather than leaking under the fan-out load.
+                    response.Dispose();
+                    response = await _erClient.GetAsync(subUnitUrl);
+                    if (response.StatusCode == HttpStatusCode.NotFound)
+                    {
+                        throw new EvidenceSourcePermanentClientException(
+                            Metadata.ERROR_ORGANIZATION_NOT_FOUND,
+                            $"{organizationNumber} was not found in the Central Coordinating Register for Legal Entities");
+                    }
                 }
-            }
 
-            rawResult = await response.Content.ReadAsStringAsync();
+                rawResult = await response.Content.ReadAsStringAsync();
+            }
+            finally
+            {
+                response.Dispose();
+            }
         }
         catch (HttpRequestException e)
         {
@@ -319,7 +329,7 @@ public class BrregService(
             }
 
             result = [];
-            var response = await _erClient.GetAsync(url);
+            using var response = await _erClient.GetAsync(url);
             if (response.StatusCode == HttpStatusCode.NotFound)
             {
                 throw new EvidenceSourcePermanentClientException(

--- a/src/Dan.Plugin.Tilda/TildaSources/TildaDataSource.cs
+++ b/src/Dan.Plugin.Tilda/TildaSources/TildaDataSource.cs
@@ -171,7 +171,7 @@ namespace Dan.Plugin.Tilda.TildaSources
                     _settings.ClientId, "brreg:tilda", null);
                 var message = new HttpRequestMessage(HttpMethod.Get, targetUrl);
                 message.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token.AccessToken);
-                var response = await _client.SendAsync(message);
+                using var response = await _client.SendAsync(message);
                 if (!response.IsSuccessStatusCode)
                 {
                     _logger.LogError(
@@ -220,7 +220,7 @@ namespace Dan.Plugin.Tilda.TildaSources
                     _settings.ClientId, "brreg:tilda", null);
                 var message = new HttpRequestMessage(HttpMethod.Get, targetUrl);
                 message.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token.AccessToken);
-                var response = await _client.SendAsync(message);
+                using var response = await _client.SendAsync(message);
                 if (!response.IsSuccessStatusCode)
                 {
                     _logger.LogError(
@@ -288,7 +288,6 @@ namespace Dan.Plugin.Tilda.TildaSources
             var resiliencePipeline = _pipelineProvider.GetPipeline("alert-pipeline");
             CloudEventFormatter formatter = new JsonEventFormatter();
             var cloudEventContent = cloudEvent.ToHttpContent(ContentMode.Structured, formatter);
-            HttpResponseMessage response;
             await resiliencePipeline.ExecuteAsync(async cancellationToken =>
             {
                 var token = await _maskinportenService.GetToken(_settings.DigdirCertificate, _settings.MaskinportenEnvironment,
@@ -296,7 +295,7 @@ namespace Dan.Plugin.Tilda.TildaSources
                 var message = new HttpRequestMessage(HttpMethod.Post, targetUrl);
                 message.Content = cloudEventContent;
                 message.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token.AccessToken);
-                response = await _alertClient.SendAsync(message, cancellationToken);
+                using var response = await _alertClient.SendAsync(message, cancellationToken);
                 if (!response.IsSuccessStatusCode)
                 {
                     throw new Exception($"Unable to post alert message to {targetUrl}, code {response.StatusCode}, reason: {response.ReasonPhrase}");


### PR DESCRIPTION
## Problem

Production logged `WSAENOBUFS` ("An operation on a socket could not be performed because the system lacked sufficient buffer space or because a queue was full") while opening new connections — first to `data.brreg.no:443`, then to `maskinporten.no:443`.

This is a **process-global** socket-buffer limit, so it surfaces on whichever host the worker happens to be dialing when buffers run dry. Capping one host at a time is whack-a-mole. The real driver is the high request fan-out (~26 tilsynsmyndigheter via `SafeHttpClient` + bounded BR enrichment) opening connections **without limit across concurrent requests** — every factory pool had the default `MaxConnectionsPerServer = int.MaxValue`.

`MaskinportenService` (Altinn lib v9.2.1) serializes token fetches behind a single shared `SemaphoreSlim`, so `maskinporten.no` was **collateral**, not a heavy consumer — confirming the exhaustion is aggregate, not per-host.

## Changes

- **Cap every `IHttpClientFactory` pool at `MaxConnectionsPerServer = 50`** with a 5-min `PooledConnectionLifetime`: `SafeHttpClient`, `AlertHttpClient`, `ERHttpClient`, `KofuviClient`, and the default/unnamed client. Per-host caps turn cross-request overload into backpressure (requests wait for a free connection) instead of socket exhaustion.
- **Register the default/unnamed client.** The singleton `MaskinportenService` receives a plain `HttpClient` (its `_client` field → the factory default-named client) for `maskinporten.no` token requests. It was previously unbounded *and* — because the service is a captured singleton — used a handler that never recycles (stale DNS on failover). Now bounded and recycled like the rest.
- **Dispose previously-leaked `HttpResponseMessage`s** in `BrregService` (ER + kofuvi paths) and `TildaDataSource` (both mtam read paths + `SendAlertMessageAsync`). The mtam non-success branch threw without reading the body or disposing, holding the connection until GC — worst exactly when failures were already cascading under load.

A follow-up commit tightens the new code comments (keep the rationale, drop the verbosity) — no behavior change.

## Testing

- `dotnet build` — succeeds, 0 errors.
- Full suite — 22/22 pass.

## Note for reviewers

`50` is **per-host**, so it does not throttle the normal one-call-per-source path; it sets the burst ceiling. If `WSAENOBUFS` recurs after deploy, the next lever is lowering the number (e.g. 32) or reducing `MaxConcurrentBrLookups`, since at that point the aggregate across all hosts is still too high for the worker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
