### PR TITLE
fix: only use id directly if scheme is null

### DIFF
--- a/src/Dan.Plugin.Tilda/Extensions/EvidenceHarvesterRequestExtension.cs
+++ b/src/Dan.Plugin.Tilda/Extensions/EvidenceHarvesterRequestExtension.cs
@@ -39,6 +39,15 @@ namespace Dan.Plugin.Tilda.Extensions
 
             return new TildaParameters(fromDateTime, toDateTime, npdid, false, sourceFilter, identifier, filter, year, month, postcode, municipalityNumber, nace);
         }
+
+        // Since Tilda supports NPDID which doesnt follow a strict scheme, we can get requests where scheme is null
+        // and that is okay, we just use the id. If scheme is set, then we don't want to use Id, as the Id will be
+        // formatted like 'scheme:id', so in that case we just pick the organisationnumber. Tilda doesnt support
+        // norwegian ssn (or any individual person) as subject, so don't need to account for that.
+        public static string GetTildaSubject(this EvidenceHarvesterRequest req)
+        {
+            return req.SubjectParty.Scheme is null ? req.SubjectParty.Id : req.SubjectParty.NorwegianOrganizationNumber;
+        }
     }
 }
 

--- a/src/Dan.Plugin.Tilda/Functions/AuditCoordinationFunctions.cs
+++ b/src/Dan.Plugin.Tilda/Functions/AuditCoordinationFunctions.cs
@@ -8,6 +8,7 @@ using Dan.Plugin.Tilda.Models;
 using Dan.Plugin.Tilda.Services;
 using Dan.Plugin.Tilda.Utils;
 using Dan.Tilda.Models.Audits.Coordination;
+using Dan.Tilda.Models.Audits.Report;
 using Dan.Tilda.Models.Entities;
 using Dan.Tilda.Models.Enums;
 using Microsoft.Azure.Functions.Worker;
@@ -74,6 +75,18 @@ public class AuditCoordinationFunctions(
             list.Add(values);
         }
 
+        var ecb = new EvidenceBuilder(metadata, "TildaTilsynskoordineringv1");
+
+        // If no one supports NPDID, we can basically just return an empty response this early
+        // as there is no use in looking more up without even having a valid org number
+        if (npdid && list.Count == 0)
+        {
+            ecb.AddEvidenceValue("enhetsinformasjon", null, "Enhetsregisteret", false);
+            ecb.AddEvidenceValue($"tilsynskoordineringer", JsonConvert.SerializeObject(new AuditCoordinationList(), Formatting.None), null, false);
+            var emptyResult = ecb.GetEvidenceValues();
+            return emptyResult;
+        }
+
         // need to get org number from control object if subject is npdid
         var orgs = new List<TildaRegistryEntry>();
         var orgNumber = npdid ?
@@ -92,7 +105,6 @@ public class AuditCoordinationFunctions(
             orgInfoUnavailable = brResult.OrgInfoUnavailable;
         }
 
-        var ecb = new EvidenceBuilder(metadata, "TildaTilsynskoordineringv1");
         foreach (var unit in orgs)
             ecb.AddEvidenceValue("enhetsinformasjon", JsonConvert.SerializeObject(unit), "Enhetsregisteret", false);
 

--- a/src/Dan.Plugin.Tilda/Functions/AuditCoordinationFunctions.cs
+++ b/src/Dan.Plugin.Tilda/Functions/AuditCoordinationFunctions.cs
@@ -54,7 +54,7 @@ public class AuditCoordinationFunctions(
 
     private async Task<List<EvidenceValue>> GetEvidenceValuesTilsynskoordinering(EvidenceHarvesterRequest req, TildaParameters param)
     {
-        var subject = req.SubjectParty.Id;
+        var subject = req.SubjectParty.Scheme is null ? req.SubjectParty.Id : req.SubjectParty.NorwegianOrganizationNumber;
         bool npdid = subject.Length < 9; // Assume npdid if less than 9 digits
 
         var taskList = GetReportListTasks(req, param, npdid);

--- a/src/Dan.Plugin.Tilda/Functions/AuditCoordinationFunctions.cs
+++ b/src/Dan.Plugin.Tilda/Functions/AuditCoordinationFunctions.cs
@@ -55,7 +55,7 @@ public class AuditCoordinationFunctions(
 
     private async Task<List<EvidenceValue>> GetEvidenceValuesTilsynskoordinering(EvidenceHarvesterRequest req, TildaParameters param)
     {
-        var subject = req.SubjectParty.Scheme is null ? req.SubjectParty.Id : req.SubjectParty.NorwegianOrganizationNumber;
+        var subject = req.GetTildaSubject();
         bool npdid = subject.Length < 9; // Assume npdid if less than 9 digits
 
         var taskList = GetReportListTasks(req, param, npdid);

--- a/src/Dan.Plugin.Tilda/Functions/AuditReportFunctions.cs
+++ b/src/Dan.Plugin.Tilda/Functions/AuditReportFunctions.cs
@@ -54,7 +54,7 @@ public class AuditReportFunctions(
 
     private async Task<List<EvidenceValue>> GetEvidenceValuesTilsynsrapport(EvidenceHarvesterRequest req, TildaParameters param)
     {
-        var subject = req.SubjectParty.Id;
+        var subject = req.SubjectParty.Scheme is null ? req.SubjectParty.Id : req.SubjectParty.NorwegianOrganizationNumber;
         bool npdid = subject.Length < 9; // Assume npdid if less than 9 digits
 
 

--- a/src/Dan.Plugin.Tilda/Functions/AuditReportFunctions.cs
+++ b/src/Dan.Plugin.Tilda/Functions/AuditReportFunctions.cs
@@ -75,6 +75,18 @@ public class AuditReportFunctions(
             list.Add(values);
         }
 
+        var ecb = new EvidenceBuilder(metadata, "TildaTilsynsrapportv1");
+
+        // If no one supports NPDID, we can basically just return an empty response this early
+        // as there is no use in looking more up without even having a valid org number
+        if (npdid && list.Count == 0)
+        {
+            ecb.AddEvidenceValue("enhetsinformasjon", null, "Enhetsregisteret", false);
+            ecb.AddEvidenceValue($"tilsynsrapporter", JsonConvert.SerializeObject(new AuditReportList(), Formatting.None), null, false);
+            var emptyResult = ecb.GetEvidenceValues();
+            return emptyResult;
+        }
+
         // need to get org number from control object if subject is npdid
         var orgs = new List<TildaRegistryEntry>();
         var orgNumber = npdid ?
@@ -92,8 +104,6 @@ public class AuditReportFunctions(
             orgs = brResult.Organizations;
             orgInfoUnavailable = brResult.OrgInfoUnavailable;
         }
-
-        var ecb = new EvidenceBuilder(metadata, "TildaTilsynsrapportv1");
 
         foreach (var unit in orgs)
         {

--- a/src/Dan.Plugin.Tilda/Functions/AuditReportFunctions.cs
+++ b/src/Dan.Plugin.Tilda/Functions/AuditReportFunctions.cs
@@ -54,7 +54,7 @@ public class AuditReportFunctions(
 
     private async Task<List<EvidenceValue>> GetEvidenceValuesTilsynsrapport(EvidenceHarvesterRequest req, TildaParameters param)
     {
-        var subject = req.SubjectParty.Scheme is null ? req.SubjectParty.Id : req.SubjectParty.NorwegianOrganizationNumber;
+        var subject = req.GetTildaSubject();
         bool npdid = subject.Length < 9; // Assume npdid if less than 9 digits
 
 

--- a/src/Dan.Plugin.Tilda/TildaSources/Digitaliseringsdirektoratet.cs
+++ b/src/Dan.Plugin.Tilda/TildaSources/Digitaliseringsdirektoratet.cs
@@ -1,19 +1,8 @@
-using System;
 using System.Net.Http;
-using System.Threading.Tasks;
 using Altinn.ApiClients.Maskinporten.Interfaces;
-using Dan.Common.Models;
 using Dan.Plugin.Tilda.Config;
-using Dan.Plugin.Tilda.Extensions;
-using Dan.Plugin.Tilda.Models;
 using Dan.Plugin.Tilda.Utils;
 using Dan.Plugin.Tilda.Interfaces;
-using Dan.Plugin.Tilda.Services;
-using Dan.Tilda.Models.Audits.Alerts;
-using Dan.Tilda.Models.Audits.Coordination;
-using Dan.Tilda.Models.Audits.NPDID;
-using Dan.Tilda.Models.Audits.Report;
-using Dan.Tilda.Models.Audits.Trend;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Polly.Registry;
@@ -32,8 +21,6 @@ namespace Dan.Plugin.Tilda.TildaSources
 
         public override bool TestOnly => true;
 
-        private readonly string _code;
-
         public Digitaliseringsdirektoratet(IOptions<Settings> settings,
             IHttpClientFactory httpClientFactory,
             ILoggerFactory loggerFactory,
@@ -42,182 +29,12 @@ namespace Dan.Plugin.Tilda.TildaSources
             IMaskinportenService maskinportenService) :
             base(settings, httpClientFactory, loggerFactory, pipelineProvider, uriFormatter, maskinportenService)
         {
-            _code = _settings.GetClassBaseCode(GetType().Name);
         }
 
         public Digitaliseringsdirektoratet() : base()
         {
 
         }
-
-        public override async Task<TrendReportList> GetDataTrendAllAsync(EvidenceHarvesterRequest req, string month, string year, string filter)
-        {
-            return await GetDataTrendAsync(req, null, null);
-        }
-
-        public override async Task<AuditReportList> GetAuditReportsAllAsync(EvidenceHarvesterRequest req, string month, string year, string filter)
-        {
-            return await GetAuditReportsAsync(req, null, null);
-        }
-        public override async Task<AuditCoordinationList> GetAuditCoordinationAllAsync(EvidenceHarvesterRequest req, string month, string year, string filter)
-        {
-
-            var resultList = new AuditCoordinationList(OrganizationNumber);
-            try
-            {
-
-                var mock = new Mock();
-
-                resultList.AuditCoordinations.AddRange(await mock.GetMockCoordinationReports(req.OrganizationNumber, OrganizationNumber, ControlAgency));
-                resultList.AuditCoordinations.AddRange(await mock.GetMockCoordinationReports("983175155", OrganizationNumber, ControlAgency));
-                resultList.AuditCoordinations.AddRange(await mock.GetMockCoordinationReports("999601391", OrganizationNumber, ControlAgency));
-
-                if (resultList.AuditCoordinations.Count == 0)
-                {
-                    resultList = Helpers.GetEmptyResponseCoordinationList(OrganizationNumber);
-                }
-            }
-            catch (Exception)
-            {
-                resultList = Helpers.GetEmptyFailedResponseCoordinationList(OrganizationNumber);
-            }
-
-            return resultList;
-
-
-        }
-
-
-        public override async Task<AlertMessageList> GetAlertMessagesAsync(EvidenceHarvesterRequest req, string month, string year, string identifier)
-        {
-            var url = GetUriAll(BaseUri, AlertDatasetName, req.Requestor, month, year, identifier);
-            var list = new AlertMessageList(OrganizationNumber);
-
-            try
-            {
-                list.AlertMessages.AddRange(await new Mock().GetMockAlertMessages(req.OrganizationNumber, OrganizationNumber, ControlAgency, Guid.NewGuid().ToString()));
-
-                if (list.AlertMessages.Count > 0)
-                    list.SetStatusAndTextAndOwner("OK", Dan.Tilda.Models.Enums.StatusEnum.Ok, OrganizationNumber);
-                else
-                    list.SetStatusAndTextAndOwner("Tomt", Dan.Tilda.Models.Enums.StatusEnum.NotFound, OrganizationNumber);
-            } catch (Exception ex)
-            {
-                list.SetStatusAndTextAndOwner(ex.Message, Dan.Tilda.Models.Enums.StatusEnum.Failed, OrganizationNumber);
-            }
-
-            return list;
-        }
-
-        public override async Task<AuditReportList> GetAuditReportsAsync(EvidenceHarvesterRequest req, DateTime? fromDate, DateTime? toDate)
-        {
-            var resultList = new AuditReportList(OrganizationNumber);
-            try
-            {
-
-                var mock = new Mock();
-
-                resultList.AuditReports.AddRange(await mock.GetMockAuditReports(req.OrganizationNumber, OrganizationNumber, ControlAgency));
-                resultList.AuditReports.AddRange(await mock.GetMockAuditReports(req.OrganizationNumber, OrganizationNumber, ControlAgency));
-
-                if (resultList.AuditReports.Count == 0)
-                {
-                    resultList = Helpers.GetEmptyResponseAuditReportList(OrganizationNumber);
-                }
-            }
-            catch (Exception)
-            {
-                resultList = Helpers.GetEmptyFailedResponseAuditReportList(OrganizationNumber);
-            }
-
-            return resultList;
-        }
-
-        public override async Task<TrendReportList> GetDataTrendAsync(EvidenceHarvesterRequest req, DateTime? fromDate, DateTime? toDate)
-        {
-            var resultList = new TrendReportList(OrganizationNumber);
-            try
-            {
-
-                var mock = new Mock();
-
-                resultList.TrendReports.AddRange(await mock.GetMockTrendReports(req.OrganizationNumber, OrganizationNumber, ControlAgency));
-                resultList.TrendReports.AddRange(await mock.GetMockTrendReports(req.OrganizationNumber, OrganizationNumber, ControlAgency));
-
-                if (resultList.TrendReports.Count == 0)
-                {
-                    resultList = Helpers.GetEmptyResponseTrendReportList(OrganizationNumber);
-                }
-            }
-            catch (Exception)
-            {
-                resultList = Helpers.GetEmptyFailedResponseTrendReportList(OrganizationNumber);
-            }
-
-            return resultList;
-        }
-
-        public override async Task<byte[]> GetPdfReport(EvidenceHarvesterRequest req, string internTilsynsId)
-        {
-            var url = "https://www.orimi.com/pdf-test.pdf";
-
-            return await _client.GetPdfreport(url, OrganizationNumber, _logger, req.MPToken, req.Requestor);
-        }
-
-        public override async Task<AuditCoordinationList> GetAuditCoordinationAsync(EvidenceHarvesterRequest req, DateTime? fromDate, DateTime? toDate)
-        {
-            var resultList = new AuditCoordinationList(OrganizationNumber);
-            try
-            {
-
-                var mock = new Mock();
-
-                resultList.AuditCoordinations.AddRange(await mock.GetMockCoordinationReports(req.OrganizationNumber, OrganizationNumber, ControlAgency));
-                resultList.AuditCoordinations.AddRange(await mock.GetMockCoordinationReports(req.OrganizationNumber, OrganizationNumber, ControlAgency));
-
-                if (resultList.AuditCoordinations.Count == 0)
-                {
-                    resultList = Helpers.GetEmptyResponseCoordinationList(OrganizationNumber);
-                }
-            }
-            catch (Exception)
-            {
-                resultList = Helpers.GetEmptyFailedResponseCoordinationList(OrganizationNumber);
-            }
-
-            return resultList;
-        }
-
-        public override async Task<NpdidAuditReportList> GetNPDIDAuditReportsAsync(EvidenceHarvesterRequest req, DateTime? fromDate, DateTime? toDate)
-        {
-            var url = $"{BaseUri}/npdid/{req.OrganizationNumber}";
-
-            var resultList = new NpdidAuditReportList(OrganizationNumber);
-            try
-            {
-
-                var mock = new Mock();
-
-                resultList.AuditReports.AddRange(await mock.GetMockNpdidAuditReports(req.OrganizationNumber, OrganizationNumber, ControlAgency, "342342"));
-
-                if (resultList.AuditReports.Count == 0)
-                {
-                    resultList = Helpers.GetEmptyResponseNPDIDAuditReportList(OrganizationNumber);
-                }
-            }
-            catch (Exception)
-            {
-                resultList = Helpers.GetEmptyFailedResponseNPDIDAuditReportList(OrganizationNumber);
-            }
-
-            return resultList;
-        }
-
-        protected override string GetAlertUri(string from) => $"{BaseUri}/{MtamDatasetName}?fromDate={from}&code={_code}";
-        protected override string GetSingleAlertUri(string id, string requestor) =>
-            $"{BaseUri}/{MtamDatasetName}/{id}?requestor={requestor}&code={_code}";
-
-        protected override string PostAlertUri() => $"{BaseUri}/{MtamDatasetName}?code={_code}";
     }
 
 }

--- a/src/Dan.Plugin.Tilda/TildaSources/Digitaliseringsdirektoratet.cs
+++ b/src/Dan.Plugin.Tilda/TildaSources/Digitaliseringsdirektoratet.cs
@@ -9,7 +9,7 @@ using Polly.Registry;
 
 namespace Dan.Plugin.Tilda.TildaSources
 {
-    public class Digitaliseringsdirektoratet : TildaDataSource, ITildaAlertMessage, ITildaPdfReport, ITildaNPDIDAuditReports//, ITildaAuditReports, ITildaAuditCoordination, ITildaTrendReports, ITildaTrendReportsAll, ITildaAuditCoordinationAll, ITildaAuditReportsAll, ITildaAlertMessage
+    public class Digitaliseringsdirektoratet : TildaDataSource //ITildaAlertMessage, ITildaPdfReport, ITildaNPDIDAuditReports//, ITildaAuditReports, ITildaAuditCoordination, ITildaTrendReports, ITildaTrendReportsAll, ITildaAuditCoordinationAll, ITildaAuditReportsAll, ITildaAlertMessage
     {
 
         private const string orgNo = "991825827";

--- a/src/Dan.Plugin.Tilda/TildaSources/TestTilsyn.cs
+++ b/src/Dan.Plugin.Tilda/TildaSources/TestTilsyn.cs
@@ -1,0 +1,52 @@
+using Altinn.ApiClients.Maskinporten.Interfaces;
+using Dan.Plugin.Tilda.Config;
+using Dan.Plugin.Tilda.Interfaces;
+using Dan.Plugin.Tilda.Utils;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Polly.Registry;
+using System.Net.Http;
+
+namespace Dan.Plugin.Tilda.TildaSources
+{
+    public class TestTilsyn : TildaDataSource, ITildaAlertMessage
+    {
+        private const string orgNo = "111111111";
+        private const string controlAgency = "TestTilsyn";
+
+        public override string OrganizationNumber
+        {
+            get => orgNo;
+        }
+
+        public override string ControlAgency
+        {
+            get => controlAgency;
+        }
+
+        public override bool TestOnly => true;
+        private readonly string _code;
+
+        public TestTilsyn(IOptions<Settings> settings,
+            IHttpClientFactory httpClientFactory,
+            ILoggerFactory loggerFactory,
+            ResiliencePipelineProvider<string> pipelineProvider,
+            IUriFormatter uriFormatter,
+            IMaskinportenService maskinportenService) :
+            base(settings, httpClientFactory, loggerFactory, pipelineProvider, uriFormatter, maskinportenService)
+        {
+            _code = _settings.GetClassBaseCode(GetType().Name);
+        }
+
+        public TestTilsyn() : base()
+        {
+
+        }
+
+        protected override string GetAlertUri(string from) => $"{BaseUri}/{MtamDatasetName}?fromDate={from}&code={_code}";
+        protected override string GetSingleAlertUri(string id, string requestor) =>
+            $"{BaseUri}/{MtamDatasetName}/{id}?requestor={requestor}&code={_code}";
+
+        protected override string PostAlertUri() => $"{BaseUri}/{MtamDatasetName}?code={_code}";
+    }
+}

--- a/src/Dan.Plugin.Tilda/TildaSources/TildaDataSource.cs
+++ b/src/Dan.Plugin.Tilda/TildaSources/TildaDataSource.cs
@@ -83,8 +83,7 @@ namespace Dan.Plugin.Tilda.TildaSources
 
         public virtual async Task<AuditReportList> GetAuditReportsAsync(EvidenceHarvesterRequest req, DateTime? fromDate, DateTime? toDate)
         {
-            var subject = req.SubjectParty.Scheme is null ? req.SubjectParty.Id : req.SubjectParty.NorwegianOrganizationNumber;
-            var url = GetUri(BaseUri, AuditReportDatasetName, subject, req.Requestor, fromDate,
+            var url = GetUri(BaseUri, AuditReportDatasetName, req.GetTildaSubject(), req.Requestor, fromDate,
                 toDate);
 
             return await _client.GetData<AuditReportList>(url, OrganizationNumber, _logger, req.MPToken, req.Requestor);
@@ -110,8 +109,7 @@ namespace Dan.Plugin.Tilda.TildaSources
 
         public virtual async Task<AuditCoordinationList> GetAuditCoordinationAsync(EvidenceHarvesterRequest req, DateTime? fromDate, DateTime? toDate)
         {
-            var subject = req.SubjectParty.Scheme is null ? req.SubjectParty.Id : req.SubjectParty.NorwegianOrganizationNumber;
-            var url = GetUri(BaseUri, CoordinationDatasetName, subject, req.Requestor, fromDate, toDate);
+            var url = GetUri(BaseUri, CoordinationDatasetName, req.GetTildaSubject(), req.Requestor, fromDate, toDate);
             return await _client.GetData<AuditCoordinationList>(url, OrganizationNumber, _logger, req.MPToken, req.Requestor);
         }
 
@@ -123,8 +121,7 @@ namespace Dan.Plugin.Tilda.TildaSources
 
         public virtual async Task<NpdidAuditReportList> GetNPDIDAuditReportsAsync(EvidenceHarvesterRequest req, DateTime? fromDate, DateTime? toDate)
         {
-            var subject = req.SubjectParty.Scheme is null ? req.SubjectParty.Id : req.SubjectParty.NorwegianOrganizationNumber;
-            var url = GetUri(BaseUri, NpdidDatasetName, subject, req.Requestor, fromDate, toDate, null);
+            var url = GetUri(BaseUri, NpdidDatasetName, req.GetTildaSubject(), req.Requestor, fromDate, toDate, null);
             return await _client.GetData<NpdidAuditReportList>(url, OrganizationNumber, _logger, req.MPToken, req.Requestor);
         }
 

--- a/src/Dan.Plugin.Tilda/TildaSources/TildaDataSource.cs
+++ b/src/Dan.Plugin.Tilda/TildaSources/TildaDataSource.cs
@@ -83,7 +83,8 @@ namespace Dan.Plugin.Tilda.TildaSources
 
         public virtual async Task<AuditReportList> GetAuditReportsAsync(EvidenceHarvesterRequest req, DateTime? fromDate, DateTime? toDate)
         {
-            var url = GetUri(BaseUri, AuditReportDatasetName, req.SubjectParty.Id, req.Requestor, fromDate,
+            var subject = req.SubjectParty.Scheme is null ? req.SubjectParty.Id : req.SubjectParty.NorwegianOrganizationNumber;
+            var url = GetUri(BaseUri, AuditReportDatasetName, subject, req.Requestor, fromDate,
                 toDate);
 
             return await _client.GetData<AuditReportList>(url, OrganizationNumber, _logger, req.MPToken, req.Requestor);
@@ -109,7 +110,8 @@ namespace Dan.Plugin.Tilda.TildaSources
 
         public virtual async Task<AuditCoordinationList> GetAuditCoordinationAsync(EvidenceHarvesterRequest req, DateTime? fromDate, DateTime? toDate)
         {
-            var url = GetUri(BaseUri, CoordinationDatasetName, req.SubjectParty.Id, req.Requestor, fromDate, toDate);
+            var subject = req.SubjectParty.Scheme is null ? req.SubjectParty.Id : req.SubjectParty.NorwegianOrganizationNumber;
+            var url = GetUri(BaseUri, CoordinationDatasetName, subject, req.Requestor, fromDate, toDate);
             return await _client.GetData<AuditCoordinationList>(url, OrganizationNumber, _logger, req.MPToken, req.Requestor);
         }
 
@@ -121,7 +123,8 @@ namespace Dan.Plugin.Tilda.TildaSources
 
         public virtual async Task<NpdidAuditReportList> GetNPDIDAuditReportsAsync(EvidenceHarvesterRequest req, DateTime? fromDate, DateTime? toDate)
         {
-            var url = GetUri(BaseUri, NpdidDatasetName, req.SubjectParty.Id, req.Requestor, fromDate, toDate, null);
+            var subject = req.SubjectParty.Scheme is null ? req.SubjectParty.Id : req.SubjectParty.NorwegianOrganizationNumber;
+            var url = GetUri(BaseUri, NpdidDatasetName, subject, req.Requestor, fromDate, toDate, null);
             return await _client.GetData<NpdidAuditReportList>(url, OrganizationNumber, _logger, req.MPToken, req.Requestor);
         }
 


### PR DESCRIPTION
### Description
If scheme is not null, subjectparty id is prepended with scheme id. Only use id directly if scheme is null

### Documentation
- [ ] Doc updated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new test-only Tilda data source with fixed organization details and predefined alert endpoints for testing.

* **Bug Fixes**
  * Improved subject identifier handling when fetching audit coordination and audit reports, ensuring the correct report/evidence sources are queried.
  * When no coordination/report results are found, the system now returns a consistent empty evidence payload and skips unnecessary follow-up steps.

* **Chores**
  * Simplified the Digitaliseringsdirektoratet Tilda data source implementation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->